### PR TITLE
Switch to low-privileged user by default

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -64,6 +64,7 @@ The following parameters are available in the `pgbackrest` class:
 * [`manage_pgpass`](#-pgbackrest--manage_pgpass)
 * [`manage_hba`](#-pgbackrest--manage_hba)
 * [`manage_cron`](#-pgbackrest--manage_cron)
+* [`manage_user`](#-pgbackrest--manage_user)
 * [`manage_package`](#-pgbackrest--manage_package)
 * [`purge_cron`](#-pgbackrest--purge_cron)
 * [`host_group`](#-pgbackrest--host_group)
@@ -122,6 +123,14 @@ Data type: `Boolean`
 
 Default value: `true`
 
+##### <a name="-pgbackrest--manage_user"></a>`manage_user`
+
+Data type: `Boolean`
+
+
+
+Default value: `true`
+
 ##### <a name="-pgbackrest--manage_package"></a>`manage_package`
 
 Data type: `Boolean`
@@ -166,7 +175,7 @@ Default value: `'pgbackrest'`
 
 Data type: `String`
 
-`installed` or specific version
+`installed` or specific version. Exactly the same version needs to be on stanza and repository server.
 
 Default value: `'present'`
 
@@ -184,7 +193,7 @@ Data type: `String`
 
 DB role for backup operations
 
-Default value: `'postgres'`
+Default value: `'backup'`
 
 ##### <a name="-pgbackrest--backup_user"></a>`backup_user`
 
@@ -192,7 +201,7 @@ Data type: `String`
 
 
 
-Default value: `'backup'`
+Default value: `'pgbackup'`
 
 ##### <a name="-pgbackrest--ssh_user"></a>`ssh_user`
 
@@ -200,7 +209,7 @@ Data type: `String`
 
 
 
-Default value: `'postgres'`
+Default value: `'pgbackup'`
 
 ##### <a name="-pgbackrest--backup_group"></a>`backup_group`
 
@@ -208,7 +217,7 @@ Data type: `String`
 
 Unix account used (mainly) for storing backups
 
-Default value: `'backup'`
+Default value: `'pgbackup'`
 
 ##### <a name="-pgbackrest--config_dir"></a>`config_dir`
 
@@ -611,15 +620,18 @@ The following parameters are available in the `pgbackrest::stanza` class:
 * [`manage_pgpass`](#-pgbackrest--stanza--manage_pgpass)
 * [`manage_hba`](#-pgbackrest--stanza--manage_hba)
 * [`manage_cron`](#-pgbackrest--stanza--manage_cron)
+* [`manage_user`](#-pgbackrest--stanza--manage_user)
 * [`host_key_type`](#-pgbackrest--stanza--host_key_type)
 * [`ssh_key_type`](#-pgbackrest--stanza--ssh_key_type)
 * [`log_dir`](#-pgbackrest--stanza--log_dir)
-* [`backup_user`](#-pgbackrest--stanza--backup_user)
 * [`log_level_file`](#-pgbackrest--stanza--log_level_file)
 * [`compress_type`](#-pgbackrest--stanza--compress_type)
 * [`compress_level`](#-pgbackrest--stanza--compress_level)
 * [`process_max`](#-pgbackrest--stanza--process_max)
 * [`password_encryption`](#-pgbackrest--stanza--password_encryption)
+* [`user_shell`](#-pgbackrest--stanza--user_shell)
+* [`user_ensure`](#-pgbackrest--stanza--user_ensure)
+* [`uid`](#-pgbackrest--stanza--uid)
 
 ##### <a name="-pgbackrest--stanza--id"></a>`id`
 
@@ -756,7 +768,7 @@ Data type: `String`
 
 user used for ssh connection to the DB instance
 
-Default value: `'postgres'`
+Default value: `$pgbackrest::ssh_user`
 
 ##### <a name="-pgbackrest--stanza--ssh_port"></a>`ssh_port`
 
@@ -805,7 +817,7 @@ Data type: `String`
 
 
 
-Default value: `'postgres'`
+Default value: `$pgbackrest::backup_user`
 
 ##### <a name="-pgbackrest--stanza--group"></a>`group`
 
@@ -813,13 +825,13 @@ Data type: `String`
 
 
 
-Default value: `'postgres'`
+Default value: `$pgbackrest::backup_group`
 
 ##### <a name="-pgbackrest--stanza--manage_dbuser"></a>`manage_dbuser`
 
 Data type: `Boolean`
 
-
+whether db role should be managed
 
 Default value: `true`
 
@@ -863,6 +875,14 @@ Data type: `Boolean`
 
 Default value: `$pgbackrest::manage_cron`
 
+##### <a name="-pgbackrest--stanza--manage_user"></a>`manage_user`
+
+Data type: `Boolean`
+
+whether unix user account should be managed
+
+Default value: `$pgbackrest::manage_user`
+
 ##### <a name="-pgbackrest--stanza--host_key_type"></a>`host_key_type`
 
 Data type: `String`
@@ -886,14 +906,6 @@ Data type: `Stdlib::AbsolutePath`
 
 
 Default value: `$pgbackrest::log_dir`
-
-##### <a name="-pgbackrest--stanza--backup_user"></a>`backup_user`
-
-Data type: `String`
-
-
-
-Default value: `$pgbackrest::backup_user`
 
 ##### <a name="-pgbackrest--stanza--log_level_file"></a>`log_level_file`
 
@@ -934,6 +946,30 @@ Data type: `Postgresql::Pg_password_encryption`
 
 
 Default value: `$pgbackrest::password_encryption`
+
+##### <a name="-pgbackrest--stanza--user_shell"></a>`user_shell`
+
+Data type: `String`
+
+
+
+Default value: `'/bin/bash'`
+
+##### <a name="-pgbackrest--stanza--user_ensure"></a>`user_ensure`
+
+Data type: `Enum['present', 'absent']`
+
+
+
+Default value: `'present'`
+
+##### <a name="-pgbackrest--stanza--uid"></a>`uid`
+
+Data type: `Optional[Integer]`
+
+user account ID
+
+Default value: `undef`
 
 ## Functions
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -193,7 +193,7 @@ Data type: `String`
 
 DB role for backup operations
 
-Default value: `'backup'`
+Default value: `'pgbackup'`
 
 ##### <a name="-pgbackrest--backup_user"></a>`backup_user`
 
@@ -315,6 +315,7 @@ The following parameters are available in the `pgbackrest::repository` class:
 * [`manage_user`](#-pgbackrest--repository--manage_user)
 * [`manage_config`](#-pgbackrest--repository--manage_config)
 * [`password_encryption`](#-pgbackrest--repository--password_encryption)
+* [`user_home`](#-pgbackrest--repository--user_home)
 
 ##### <a name="-pgbackrest--repository--fqdn"></a>`fqdn`
 
@@ -572,6 +573,14 @@ Data type: `Postgresql::Pg_password_encryption`
 
 Default value: `$pgbackrest::password_encryption`
 
+##### <a name="-pgbackrest--repository--user_home"></a>`user_home`
+
+Data type: `Optional[Stdlib::AbsolutePath]`
+
+Path to backup user home directory on stanza server
+
+Default value: `undef`
+
 ### <a name="pgbackrest--stanza"></a>`pgbackrest::stanza`
 
 Manages configuration for postgresql database backup
@@ -623,6 +632,7 @@ The following parameters are available in the `pgbackrest::stanza` class:
 * [`manage_cron`](#-pgbackrest--stanza--manage_cron)
 * [`manage_user`](#-pgbackrest--stanza--manage_user)
 * [`manage_user_home`](#-pgbackrest--stanza--manage_user_home)
+* [`manage_archive_cmd`](#-pgbackrest--stanza--manage_archive_cmd)
 * [`host_key_type`](#-pgbackrest--stanza--host_key_type)
 * [`ssh_key_type`](#-pgbackrest--stanza--ssh_key_type)
 * [`log_dir`](#-pgbackrest--stanza--log_dir)
@@ -635,6 +645,7 @@ The following parameters are available in the `pgbackrest::stanza` class:
 * [`user_ensure`](#-pgbackrest--stanza--user_ensure)
 * [`user_home`](#-pgbackrest--stanza--user_home)
 * [`uid`](#-pgbackrest--stanza--uid)
+* [`groups`](#-pgbackrest--stanza--groups)
 
 ##### <a name="-pgbackrest--stanza--hostname"></a>`hostname`
 
@@ -902,6 +913,14 @@ Whether user's home directory should be created by puppet
 
 Default value: `true`
 
+##### <a name="-pgbackrest--stanza--manage_archive_cmd"></a>`manage_archive_cmd`
+
+Data type: `Boolean`
+
+Whether archive_command should be set on postgresql instance, changing archive_mode requires restart
+
+Default value: `true`
+
 ##### <a name="-pgbackrest--stanza--host_key_type"></a>`host_key_type`
 
 Data type: `String`
@@ -997,6 +1016,14 @@ Data type: `Optional[Integer]`
 user account ID
 
 Default value: `undef`
+
+##### <a name="-pgbackrest--stanza--groups"></a>`groups`
+
+Data type: `Array[String]`
+
+Unix groups to which the $user will belong
+
+Default value: `['postgres']`
 
 ## Functions
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -632,6 +632,7 @@ The following parameters are available in the `pgbackrest::stanza` class:
 * [`password_encryption`](#-pgbackrest--stanza--password_encryption)
 * [`user_shell`](#-pgbackrest--stanza--user_shell)
 * [`user_ensure`](#-pgbackrest--stanza--user_ensure)
+* [`user_home`](#-pgbackrest--stanza--user_home)
 * [`uid`](#-pgbackrest--stanza--uid)
 
 ##### <a name="-pgbackrest--stanza--hostname"></a>`hostname`
@@ -971,6 +972,14 @@ Data type: `Enum['present', 'absent']`
 
 
 Default value: `'present'`
+
+##### <a name="-pgbackrest--stanza--user_home"></a>`user_home`
+
+Data type: `Optional[Stdlib::AbsolutePath]`
+
+Path to backup user home directory
+
+Default value: `undef`
 
 ##### <a name="-pgbackrest--stanza--uid"></a>`uid`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -622,6 +622,7 @@ The following parameters are available in the `pgbackrest::stanza` class:
 * [`manage_hba`](#-pgbackrest--stanza--manage_hba)
 * [`manage_cron`](#-pgbackrest--stanza--manage_cron)
 * [`manage_user`](#-pgbackrest--stanza--manage_user)
+* [`manage_user_home`](#-pgbackrest--stanza--manage_user_home)
 * [`host_key_type`](#-pgbackrest--stanza--host_key_type)
 * [`ssh_key_type`](#-pgbackrest--stanza--ssh_key_type)
 * [`log_dir`](#-pgbackrest--stanza--log_dir)
@@ -889,9 +890,17 @@ Default value: `$pgbackrest::manage_cron`
 
 Data type: `Boolean`
 
-whether unix user account should be managed
+Whether unix user account should be managed
 
 Default value: `$pgbackrest::manage_user`
+
+##### <a name="-pgbackrest--stanza--manage_user_home"></a>`manage_user_home`
+
+Data type: `Boolean`
+
+Whether user's home directory should be created by puppet
+
+Default value: `true`
 
 ##### <a name="-pgbackrest--stanza--host_key_type"></a>`host_key_type`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -590,10 +590,11 @@ include pgbackrest::stanza
 
 The following parameters are available in the `pgbackrest::stanza` class:
 
+* [`hostname`](#-pgbackrest--stanza--hostname)
 * [`id`](#-pgbackrest--stanza--id)
 * [`cluster`](#-pgbackrest--stanza--cluster)
-* [`host_group`](#-pgbackrest--stanza--host_group)
 * [`repo`](#-pgbackrest--stanza--repo)
+* [`host_group`](#-pgbackrest--stanza--host_group)
 * [`version`](#-pgbackrest--stanza--version)
 * [`address`](#-pgbackrest--stanza--address)
 * [`port`](#-pgbackrest--stanza--port)
@@ -633,13 +634,21 @@ The following parameters are available in the `pgbackrest::stanza` class:
 * [`user_ensure`](#-pgbackrest--stanza--user_ensure)
 * [`uid`](#-pgbackrest--stanza--uid)
 
-##### <a name="-pgbackrest--stanza--id"></a>`id`
+##### <a name="-pgbackrest--stanza--hostname"></a>`hostname`
 
 Data type: `String`
 
-Unique identified
+Unique identifier
 
 Default value: `$facts['networking']['hostname']`
+
+##### <a name="-pgbackrest--stanza--id"></a>`id`
+
+Data type: `Integer[1,256]`
+
+unique number in the cluster
+
+Default value: `1`
 
 ##### <a name="-pgbackrest--stanza--cluster"></a>`cluster`
 
@@ -649,6 +658,14 @@ Cluster name in case database has primary and some replicas.
 
 Default value: `undef`
 
+##### <a name="-pgbackrest--stanza--repo"></a>`repo`
+
+Data type: `Integer[1,256]`
+
+backup repository integer ID
+
+Default value: `1`
+
 ##### <a name="-pgbackrest--stanza--host_group"></a>`host_group`
 
 Data type: `String`
@@ -656,14 +673,6 @@ Data type: `String`
 Default repository host group
 
 Default value: `$pgbackrest::host_group`
-
-##### <a name="-pgbackrest--stanza--repo"></a>`repo`
-
-Data type: `Integer[1,256]`
-
-Set the repository for a command to operate on, default: 1
-
-Default value: `1`
 
 ##### <a name="-pgbackrest--stanza--version"></a>`version`
 

--- a/lib/facter/pgbackrest_ssh_keys.rb
+++ b/lib/facter/pgbackrest_ssh_keys.rb
@@ -32,7 +32,10 @@ Facter.add(:pgbackrest) do
       File.foreach(keys) do |line|
         if line.match? regexp
           m = line.match regexp
-          res[m[1]] = pgbackrest_fetch_key(m[2])
+          path = m[2]
+          if File.exist?(path)
+            res[m[1]] = pgbackrest_fetch_key(path)
+          end
         end
       end
     end

--- a/manifests/cron_backup.pp
+++ b/manifests/cron_backup.pp
@@ -2,7 +2,7 @@
 # A cron job is exported from a database server, but could be executed elsewhere.
 # Typically on a catalog (backup) server.
 define pgbackrest::cron_backup (
-  String                          $id,
+  String                          $hostname,
   String                          $cluster,
   Integer[1,256]                  $repo,
   String                          $host_group,
@@ -30,7 +30,7 @@ define pgbackrest::cron_backup (
 ) {
   @@cron { "pgbackrest_${backup_type}_${server_address}-${host_group}":
     command  => epp('pgbackrest/cron_backup.epp', {
-        id                => $id,
+        hostname          => $hostname,
         repo              => $repo,
         cluster           => $cluster,
         db_name           => $db_name,

--- a/manifests/grants.pp
+++ b/manifests/grants.pp
@@ -16,10 +16,10 @@ class pgbackrest::grants (
     object_name => 'pg_catalog',
   }
 
-  postgresql::server::grant { "pg_read_all_settings_to_${db_user}":
-    db          => $db_name,
-    role        => $db_user,
-    object_name => 'pg_read_all_settings',
+  # GRANT pg_read_all_settings TO backup;
+  postgresql::server::grant_role { "pg_read_all_settings_to_${db_user}":
+    group => 'pg_read_all_settings',
+    role  => $db_user,
   }
 
   # GRANT EXECUTE ON FUNCTION pg_catalog.current_setting(text) TO backup;

--- a/manifests/grants.pp
+++ b/manifests/grants.pp
@@ -19,8 +19,6 @@ class pgbackrest::grants (
   postgresql::server::grant { "pg_read_all_settings_to_${db_user}":
     db          => $db_name,
     role        => $db_user,
-    privilege   => 'EXECUTE',
-    object_type => 'FUNCTION',
     object_name => 'pg_read_all_settings',
   }
 

--- a/manifests/grants.pp
+++ b/manifests/grants.pp
@@ -16,6 +16,14 @@ class pgbackrest::grants (
     object_name => 'pg_catalog',
   }
 
+  postgresql::server::grant { "pg_read_all_settings_to_${db_user}":
+    db          => $db_name,
+    role        => $db_user,
+    privilege   => 'EXECUTE',
+    object_type => 'FUNCTION',
+    object_name => 'pg_read_all_settings',
+  }
+
   # GRANT EXECUTE ON FUNCTION pg_catalog.current_setting(text) TO backup;
   postgresql::server::grant { "current_setting-to-${db_user}":
     db               => $db_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class pgbackrest (
   String               $package_name = 'pgbackrest',
   String               $package_ensure = 'present',
   String               $db_name = 'backup',
-  String               $db_user = 'backup',
+  String               $db_user = 'pgbackup',
   String               $ssh_user = 'pgbackup',
   String               $backup_user = 'pgbackup',
   String               $backup_group = 'pgbackup',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 # @param host_key_type
 #   ssh host key fingerprint, one of 'ecdsa', 'ed25519' or 'rsa'. Default: `ed25519`
 # @param package_name System package to be installed
-# @param package_ensure `installed` or specific version
+# @param package_ensure `installed` or specific version. Exactly the same version needs to be on stanza and repository server.
 # @param db_name
 # @param db_user DB role for backup operations
 # @param backup_user

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@
 # @param manage_pgpass
 # @param manage_hba
 # @param manage_cron
+# @param manage_user
 # @param manage_package Whether package should be installed by puppet
 # @param purge_cron
 # @param host_group
@@ -37,6 +38,7 @@ class pgbackrest (
   Boolean              $manage_hba = true,
   Boolean              $manage_cron = true,
   Boolean              $manage_package = true,
+  Boolean              $manage_user = true,
   Boolean              $purge_cron = true,
   String               $host_group = 'common',
   Pgbackrest::HostKey  $host_key_type = 'ed25519',
@@ -44,9 +46,9 @@ class pgbackrest (
   String               $package_ensure = 'present',
   String               $db_name = 'backup',
   String               $db_user = 'backup',
-  String               $ssh_user = 'postgres',
-  String               $backup_user = 'backup',
-  String               $backup_group = 'backup',
+  String               $ssh_user = 'pgbackup',
+  String               $backup_user = 'pgbackup',
+  String               $backup_group = 'pgbackup',
   Stdlib::AbsolutePath $config_dir = '/etc/pgbackrest',
   Stdlib::AbsolutePath $config_subdir = '/etc/pgbackrest/conf.d',
   Stdlib::AbsolutePath $backup_dir = '/var/lib/pgbackrest',

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -239,9 +239,9 @@ class pgbackrest::repository (
     Concat::Fragment <<| tag == "pgbackrest-repository-${host_group}" |>>
 
     $_home = $user_home ? {
-      undef   => $user == 'postgres' ? {
+      undef   => $ssh_user == 'postgres' ? {
         true  => '/var/lib/postgresql',
-        false => "/home/${user}",
+        false => "/home/${ssh_user}",
       },
       default => $user_home,
     }

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -37,6 +37,7 @@
 # @param manage_user
 # @param manage_config
 # @param password_encryption
+# @param user_home Path to backup user home directory on stanza server
 # @example
 #   include pgbackrest::repository
 class pgbackrest::repository (
@@ -72,6 +73,7 @@ class pgbackrest::repository (
   String                             $ssh_key_type = 'ed25519',
   Hash                               $config = {},
   Postgresql::Pg_password_encryption $password_encryption = $pgbackrest::password_encryption,
+  Optional[Stdlib::AbsolutePath]     $user_home = undef,
 ) inherits pgbackrest {
   if $manage_user {
     group { $group:
@@ -236,6 +238,14 @@ class pgbackrest::repository (
 
     Concat::Fragment <<| tag == "pgbackrest-repository-${host_group}" |>>
 
+    $_home = $user_home ? {
+      undef   => $user == 'postgres' ? {
+        true  => '/var/lib/postgresql',
+        false => "/home/${user}",
+      },
+      default => $user_home,
+    }
+
     # Load ssh public key for given local user
     # NOTE: we can't access remote disk from a compile server
     # and exported resources doesn't support Deferred objects
@@ -247,6 +257,7 @@ class pgbackrest::repository (
         type   => $facts['pgbackrest'][$user]['type'],
         key    => $ssh_key,
         tag    => "pgbackrest-repository-${host_group}",
+        target => "${_home}/.ssh/authorized_keys",
       }
     }
   }

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -246,7 +246,6 @@ class pgbackrest::stanza (
     # Load ssh public key for given local user
     # NOTE: we can't access remote disk from a compile server
     # and exported resources doesn't support Deferred objects
-
     if 'pgbackrest' in $facts and $ssh_user in $facts['pgbackrest'] {
       $ssh_key = $facts['pgbackrest'][$ssh_user]['key']
       @@ssh_authorized_key { "${ssh_user}-${address}":

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -212,12 +212,19 @@ class pgbackrest::stanza (
   }
 
   if $manage_ssh_keys {
+    file { "${_home}/.ssh":
+      ensure => directory,
+      owner  => $user,
+      mode   => '0600',
+    }
+
     $privkey_path = pgbackrest::ssh_key_path("${_home}/.ssh", $ssh_key_type, false)
     $pubkey_path = pgbackrest::ssh_key_path("${_home}/.ssh", $ssh_key_type, true)
     exec { "pgbackrest-generate-ssh-key_${ssh_user}":
       command => "su - ${ssh_user} -c \"ssh-keygen -t ${ssh_key_type} -q -N '' -f ${privkey_path}\"",
       path    => ['/usr/bin'],
       onlyif  => "test ! -f ${privkey_path}",
+      require => File["${_home}/.ssh"],
     }
 
     file { '/var/cache/pgbackrest':

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -2,14 +2,11 @@
 #
 # Manages configuration for postgresql database backup
 #
-# @param id
-#   Unique identified
-# @param cluster
-#   Cluster name in case database has primary and some replicas.
-# @param host_group
-#   Default repository host group
-# @param repo
-#   Set the repository for a command to operate on, default: 1
+# @param hostname Unique identifier
+# @param id unique number in the cluster
+# @param cluster Cluster name in case database has primary and some replicas.
+# @param repo backup repository integer ID
+# @param host_group Default repository host group
 # @param version PostgreSQL major version, e.g. '16'
 # @param address
 # @param port
@@ -66,10 +63,11 @@
 # @example
 #   include pgbackrest::stanza
 class pgbackrest::stanza (
-  String                             $id                   = $facts['networking']['hostname'],
+  String                             $hostname             = $facts['networking']['hostname'],
+  Integer[1,256]                     $id                   = 1,
+  Integer[1,256]                     $repo                 = 1,
   Optional[String]                   $cluster              = undef,
   String                             $host_group           = $pgbackrest::host_group,
-  Integer[1,256]                     $repo                 = 1,
   String                             $address              = $facts['networking']['fqdn'],
   Integer                            $port                 = 5432,
   String                             $db_name              = $pgbackrest::db_name,
@@ -115,7 +113,7 @@ class pgbackrest::stanza (
   }
 
   $_cluster = $cluster ? {
-    undef   => $id,
+    undef   => $hostname,
     default => $cluster
   }
 
@@ -243,7 +241,7 @@ class pgbackrest::stanza (
 
   if $manage_pgpass {
     # Export .pgpass content to pgprobackup catalog
-    @@file_line { "pgbackrest_pgpass_content-${id}":
+    @@file_line { "pgbackrest_pgpass_content-${hostname}":
       path  => "${backup_dir}/.pgpass",
       line  => "${address}:${port}:${db_name}:${db_user}:${real_password}",
       match => "^${regexpescape($address)}:${port}:${db_name}:${db_user}",
@@ -251,14 +249,14 @@ class pgbackrest::stanza (
     }
 
     # pgbackrest connects via ssh and then performs local connection
-    file_line { "pgbackrest_pgpass_-${id}":
+    file_line { "pgbackrest_pgpass_-${hostname}":
       path  => "${db_path}/.pgpass",
       line  => "*:${port}:${db_name}:${db_user}:${real_password}",
       match => "^*:${port}:${db_name}:${db_user}",
       tag   => $tags,
     }
 
-    @@file_line { "pgbackrest_pgpass_replication-${id}":
+    @@file_line { "pgbackrest_pgpass_replication-${hostname}":
       path  => "${backup_dir}/.pgpass",
       line  => "${address}:${port}:replication:${db_user}:${real_password}",
       match => "^${regexpescape($address)}:${port}:replication:${db_user}",
@@ -270,12 +268,12 @@ class pgbackrest::stanza (
 
   $db_conf = {
     'log-level-console' => $log_level_console,
-    'pg1-host' => $address,
-    'pg1-path' => "${db_path}/${_version}/${db_cluster}",
-    'pg1-port' => $port,
-    'pg1-database' => $db_name,
-    'pg1-user' => $db_user,
-    'pg1-host-user' => $ssh_user,
+    "pg${id}-host" => $address,
+    "pg${id}-path" => "${db_path}/${_version}/${db_cluster}",
+    "pg${id}-port" => $port,
+    "pg${id}-database" => $db_name,
+    "pg${id}-user" => $db_user,
+    "pg${id}-host-user" => $ssh_user,
   }
 
   # local config
@@ -333,7 +331,7 @@ class pgbackrest::stanza (
         $config.each |$backup_type, $schedule| {
           # declare cron job, use defaults from stanza
           create_resources(pgbackrest::cron_backup, { "cron_backup-${host_group}-${address}-${backup_type}" => $schedule }, {
-              id                   => $id,
+              hostname             => $hostname,
               repo                 => $repo,
               cluster              => $_cluster,
               db_name              => $db_name,

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -44,21 +44,24 @@
 #   Redirect console output to a log file (make sense especially with custom backup command)
 # @param user
 # @param group
-# @param manage_dbuser
+# @param manage_dbuser whether db role should be managed
 # @param manage_ssh_keys
 # @param manage_host_keys
 # @param manage_pgpass
 # @param manage_hba
 # @param manage_cron
+# @param manage_user whether unix user account should be managed
 # @param host_key_type
 # @param ssh_key_type
 # @param log_dir
-# @param backup_user
 # @param log_level_file
 # @param compress_type
 # @param compress_level
 # @param process_max
 # @param password_encryption
+# @param user_shell
+# @param user_ensure
+# @param uid user account ID
 #
 # @example
 #   include pgbackrest::stanza
@@ -76,15 +79,16 @@ class pgbackrest::stanza (
   Stdlib::AbsolutePath               $db_path              = '/var/lib/postgresql',
   Optional[Pgbackrest::Secret]       $db_password          = undef,
   Optional[String]                   $seed                 = undef,
-  String                             $user                 = 'postgres',
-  String                             $group                = 'postgres',
+  String                             $user                 = $pgbackrest::backup_user,
+  String                             $group                = $pgbackrest::backup_group,
   Boolean                            $manage_dbuser        = true,
   Boolean                            $manage_ssh_keys      = $pgbackrest::manage_ssh_keys,
   Boolean                            $manage_host_keys     = $pgbackrest::manage_host_keys,
   Boolean                            $manage_pgpass        = $pgbackrest::manage_pgpass,
   Boolean                            $manage_hba           = $pgbackrest::manage_hba,
   Boolean                            $manage_cron          = $pgbackrest::manage_cron,
-  String                             $ssh_user             = 'postgres',
+  Boolean                            $manage_user          = $pgbackrest::manage_user,
+  String                             $ssh_user             = $pgbackrest::ssh_user,
   Integer                            $ssh_port             = 22,
   String                             $host_key_type        = $pgbackrest::host_key_type,
   String                             $ssh_key_type         = 'ed25519',
@@ -92,7 +96,6 @@ class pgbackrest::stanza (
   Stdlib::AbsolutePath               $spool_dir            = $pgbackrest::spool_dir,
   Stdlib::AbsolutePath               $log_dir              = $pgbackrest::log_dir,
   Postgresql::Pg_password_encryption $password_encryption  = $pgbackrest::password_encryption,
-  String                             $backup_user          = $pgbackrest::backup_user,
   Optional[Hash]                     $backups              = undef,
   Pgbackrest::LogLevel               $log_level_console    = 'warn',
   Pgbackrest::LogLevel               $log_level_file       = 'info',
@@ -102,6 +105,9 @@ class pgbackrest::stanza (
   Optional[Integer]                  $archive_timeout      = undef,
   Optional[Stdlib::AbsolutePath]     $binary               = undef,
   Boolean                            $redirect_console     = false,
+  String                             $user_shell = '/bin/bash',
+  Enum['present', 'absent']          $user_ensure = 'present',
+  Optional[Integer]                  $uid = undef,
 ) inherits pgbackrest {
   $_version = $version ? {
     undef   => lookup('postgresql::globals::version'),
@@ -125,6 +131,21 @@ class pgbackrest::stanza (
       true  => $db_password.unwrap,
       false => $db_password
     },
+  }
+
+  if $manage_user {
+    group { $group:
+      ensure => $user_ensure,
+    }
+
+    user { $user:
+      ensure  => $user_ensure,
+      uid     => $uid,
+      gid     => $group, # a primary group
+      home    => $backup_dir,
+      shell   => $user_shell,
+      require => Group[$group],
+    }
   }
 
   if $manage_dbuser {
@@ -212,7 +233,7 @@ class pgbackrest::stanza (
       $ssh_key = $facts['pgbackrest'][$ssh_user]['key']
       @@ssh_authorized_key { "${ssh_user}-${address}":
         ensure => present,
-        user   => $backup_user,
+        user   => $user,
         type   => $facts['pgbackrest'][$ssh_user]['type'],
         key    => $ssh_key,
         tag    => $tags,
@@ -289,7 +310,7 @@ class pgbackrest::stanza (
         cwd     => $backup_dir,
         #onlyif  => "test ! -d ${backup_dir}/backups/${_cluster}",
         tag     => "pgbackrest_stanza_create-${host_group}",
-        user    => $backup_user, # note: error output might not be captured
+        user    => $user, # note: error output might not be captured
         require => [Package[$pgbackrest::package_name], Class['Pgbackrest::Config']],
       }
 
@@ -320,7 +341,7 @@ class pgbackrest::stanza (
               host_group           => $host_group,
               backup_dir           => $backup_dir,
               backup_type          => $backup_type,
-              backup_user          => $backup_user,
+              backup_user          => $user,
               server_address       => $address,
               process_max          => $process_max,
               compress_type        => $compress_type,

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -268,14 +268,6 @@ class pgbackrest::stanza (
       tag   => $tags,
     }
 
-    # pgbackrest connects via ssh and then performs local connection
-    file_line { "pgbackrest_pgpass_-${hostname}":
-      path  => "${_home}/.pgpass",
-      line  => "*:${port}:${db_name}:${db_user}:${real_password}",
-      match => "^*:${port}:${db_name}:${db_user}",
-      tag   => $tags,
-    }
-
     @@file_line { "pgbackrest_pgpass_replication-${hostname}":
       path  => "${backup_dir}/.pgpass",
       line  => "${address}:${port}:replication:${db_user}:${real_password}",

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -61,6 +61,7 @@
 # @param user_ensure
 # @param user_home Path to backup user home directory
 # @param uid user account ID
+# @param groups Unix groups to which the $user will belong
 #
 # @example
 #   include pgbackrest::stanza
@@ -110,6 +111,7 @@ class pgbackrest::stanza (
   Enum['present', 'absent']          $user_ensure          = 'present',
   Optional[Stdlib::AbsolutePath]     $user_home            = undef,
   Optional[Integer]                  $uid = undef,
+  Array[String]                      $groups               = ['postgres']
 ) inherits pgbackrest {
   $_version = $version ? {
     undef   => lookup('postgresql::globals::version'),
@@ -153,6 +155,7 @@ class pgbackrest::stanza (
       uid        => $uid,
       gid        => $group, # a primary group
       home       => $_home,
+      groups     => $groups,
       managehome => $manage_user_home,
       shell      => $user_shell,
       require    => Group[$group],

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -47,7 +47,8 @@
 # @param manage_pgpass
 # @param manage_hba
 # @param manage_cron
-# @param manage_user whether unix user account should be managed
+# @param manage_user Whether unix user account should be managed
+# @param manage_user_home Whether user's home directory should be created by puppet
 # @param host_key_type
 # @param ssh_key_type
 # @param log_dir
@@ -87,6 +88,7 @@ class pgbackrest::stanza (
   Boolean                            $manage_hba           = $pgbackrest::manage_hba,
   Boolean                            $manage_cron          = $pgbackrest::manage_cron,
   Boolean                            $manage_user          = $pgbackrest::manage_user,
+  Boolean                            $manage_user_home     = true,
   String                             $ssh_user             = $pgbackrest::ssh_user,
   Integer                            $ssh_port             = 22,
   String                             $host_key_type        = $pgbackrest::host_key_type,
@@ -147,12 +149,13 @@ class pgbackrest::stanza (
     }
 
     user { $user:
-      ensure  => $user_ensure,
-      uid     => $uid,
-      gid     => $group, # a primary group
-      home    => $backup_dir,
-      shell   => $user_shell,
-      require => Group[$group],
+      ensure     => $user_ensure,
+      uid        => $uid,
+      gid        => $group, # a primary group
+      home       => $backup_dir,
+      managehome => $manage_user_home,
+      shell      => $user_shell,
+      require    => Group[$group],
     }
   }
 

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -49,6 +49,7 @@
 # @param manage_cron
 # @param manage_user Whether unix user account should be managed
 # @param manage_user_home Whether user's home directory should be created by puppet
+# @param manage_archive_cmd Whether archive_command should be set on postgresql instance, changing archive_mode requires restart
 # @param host_key_type
 # @param ssh_key_type
 # @param log_dir
@@ -89,6 +90,7 @@ class pgbackrest::stanza (
   Boolean                            $manage_hba           = $pgbackrest::manage_hba,
   Boolean                            $manage_cron          = $pgbackrest::manage_cron,
   Boolean                            $manage_user          = $pgbackrest::manage_user,
+  Boolean                            $manage_archive_cmd   = true,
   Boolean                            $manage_user_home     = true,
   String                             $ssh_user             = $pgbackrest::ssh_user,
   Integer                            $ssh_port             = 22,
@@ -312,6 +314,16 @@ class pgbackrest::stanza (
     order   => 50,
     tag     => "pgbackrest-repository-${host_group}",
     require => File[$pgbackrest::config_subdir],
+  }
+
+  if $manage_archive_cmd {
+    postgresql::server::config_entry { 'archive_mode':
+      value => 'on', # restart required
+    }
+
+    postgresql::server::config_entry { 'archive_command':
+      value => "pgbackrest --stanza=${_cluster} archive-push %p", # reload
+    }
   }
 
   if !empty($backups) {

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -152,7 +152,7 @@ class pgbackrest::stanza (
       ensure     => $user_ensure,
       uid        => $uid,
       gid        => $group, # a primary group
-      home       => $backup_dir,
+      home       => $_home,
       managehome => $manage_user_home,
       shell      => $user_shell,
       require    => Group[$group],

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -58,6 +58,7 @@
 # @param password_encryption
 # @param user_shell
 # @param user_ensure
+# @param user_home Path to backup user home directory
 # @param uid user account ID
 #
 # @example
@@ -103,8 +104,9 @@ class pgbackrest::stanza (
   Optional[Integer]                  $archive_timeout      = undef,
   Optional[Stdlib::AbsolutePath]     $binary               = undef,
   Boolean                            $redirect_console     = false,
-  String                             $user_shell = '/bin/bash',
-  Enum['present', 'absent']          $user_ensure = 'present',
+  String                             $user_shell           = '/bin/bash',
+  Enum['present', 'absent']          $user_ensure          = 'present',
+  Optional[Stdlib::AbsolutePath]     $user_home            = undef,
   Optional[Integer]                  $uid = undef,
 ) inherits pgbackrest {
   $_version = $version ? {
@@ -129,6 +131,14 @@ class pgbackrest::stanza (
       true  => $db_password.unwrap,
       false => $db_password
     },
+  }
+
+  $_home = $user_home ? {
+    undef   => $user == 'postgres' ? {
+      true  => '/var/lib/postgresql',
+      false => "/home/${user}",
+    },
+    default => $user_home,
   }
 
   if $manage_user {
@@ -199,8 +209,8 @@ class pgbackrest::stanza (
   }
 
   if $manage_ssh_keys {
-    $privkey_path = pgbackrest::ssh_key_path("${db_path}/.ssh", $ssh_key_type, false)
-    $pubkey_path = pgbackrest::ssh_key_path("${db_path}/.ssh", $ssh_key_type, true)
+    $privkey_path = pgbackrest::ssh_key_path("${_home}/.ssh", $ssh_key_type, false)
+    $pubkey_path = pgbackrest::ssh_key_path("${_home}/.ssh", $ssh_key_type, true)
     exec { "pgbackrest-generate-ssh-key_${ssh_user}":
       command => "su - ${ssh_user} -c \"ssh-keygen -t ${ssh_key_type} -q -N '' -f ${privkey_path}\"",
       path    => ['/usr/bin'],
@@ -250,7 +260,7 @@ class pgbackrest::stanza (
 
     # pgbackrest connects via ssh and then performs local connection
     file_line { "pgbackrest_pgpass_-${hostname}":
-      path  => "${db_path}/.pgpass",
+      path  => "${_home}/.pgpass",
       line  => "*:${port}:${db_name}:${db_user}:${real_password}",
       match => "^*:${port}:${db_name}:${db_user}",
       tag   => $tags,

--- a/spec/classes/grants_spec.rb
+++ b/spec/classes/grants_spec.rb
@@ -20,4 +20,14 @@ describe 'pgbackrest::grants' do
   end
 
   it { is_expected.to compile }
+
+  it {
+    is_expected.to contain_postgresql__server__grant_role("pg_read_all_settings_to_#{params[:db_user]}")
+      .with(group: 'pg_read_all_settings', role: params[:db_user])
+  }
+
+  it {
+    is_expected.to contain_postgresql_psql("grant_role:pg_read_all_settings_to_#{params[:db_user]}")
+      .with(command: "GRANT \"pg_read_all_settings\" TO \"#{params[:db_user]}\"")
+  }
 end

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -18,13 +18,13 @@ describe 'pgbackrest::repository' do
   it {
     is_expected.to contain_file('/var/lib/pgbackrest')
       .with(ensure: 'directory',
-            owner: 'backup',
-            group: 'backup',
+            owner: 'pgbackup',
+            group: 'pgbackup',
             mode: '0750')
   }
 
-  it { is_expected.to contain_user('backup') }
-  it { is_expected.to contain_group('backup') }
+  it { is_expected.to contain_user('pgbackup') }
+  it { is_expected.to contain_group('pgbackup') }
 
   context 'with manage_user: true' do
     let(:params) do
@@ -193,7 +193,7 @@ describe 'pgbackrest::repository' do
     it 'exports public ssh key' do
       expect(exported_resources).to contain_ssh_authorized_key('pgbackrest-psql.localhost')
         .with(
-          user: 'postgres',
+          user: 'pgbackup',
           type: 'ssh-ed25519',
           key: 'AAAAC3NzaC1lZDI1NTE5AAAAIN1UTKrM47QYBXJg0cIgrausN4o93I17AIj4K3i+5yS4',
         )

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -126,6 +126,40 @@ describe 'pgbackrest::stanza' do
     }
   end
 
+  context 'with manage db user' do
+    let(:params) do
+      {
+        backups: {
+          common: {
+            incr: {},
+          },
+        },
+        id: 'psql',
+        port: 5433,
+        db_name: 'pg_db',
+        db_user:  'pg_user',
+        db_password: 'TopSecret!',
+        version: '14',
+        manage_dbuser: true,
+      }
+    end
+
+    it {
+      is_expected.to contain_postgresql__server__database('pg_db').with(
+        { 'owner' => 'pg_user' },
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__role('pg_user').with(
+        {
+          'replication' => true,
+          'superuser'   => false,
+        },
+      )
+    }
+  end
+
   context 'exporting host ssh key' do
     let(:params) do
       {
@@ -165,6 +199,12 @@ describe 'pgbackrest::stanza' do
       expect(exported_resources).to contain_exec('pgbackrest_stanza_create_psql.localhost-common').with(
         tag: 'pgbackrest_stanza_create-common',
         command: 'pgbackrest stanza-create --stanza=psql',
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__database('backup').with(
+        { 'owner' => 'backup' },
       )
     }
   end

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -70,7 +70,7 @@ describe 'pgbackrest::stanza' do
 
     it 'generates ssh key pair, if missing' do
       is_expected.to contain_exec('pgbackrest-generate-ssh-key_pgbackup').with(
-        command: 'su - pgbackup -c "ssh-keygen -t ed25519 -q -N \'\' -f /var/lib/postgresql/.ssh/id_ed25519"',
+        command: 'su - pgbackup -c "ssh-keygen -t ed25519 -q -N \'\' -f /home/pgbackup/.ssh/id_ed25519"',
       )
     end
 
@@ -95,7 +95,7 @@ describe 'pgbackrest::stanza' do
       is_expected.to contain_ini_setting('pgbackrest-stanza').with(
         {
           ensure: 'present',
-          setting: 'pgbackup', value: '/var/lib/postgresql/.ssh/id_ed25519.pub',
+          setting: 'pgbackup', value: '/home/pgbackup/.ssh/id_ed25519.pub',
           path: '/var/cache/pgbackrest/exported_keys.ini'
         },
       )

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -160,6 +160,58 @@ describe 'pgbackrest::stanza' do
     }
   end
 
+  context 'archive_command' do
+    context 'when manage_archive_cmd is enabled (default)' do
+      let(:params) do
+        {
+          hostname: 'psql',
+          version: '14',
+        }
+      end
+
+      it {
+        is_expected.to contain_postgresql__server__config_entry('archive_mode').with(
+          value: 'on',
+        )
+      }
+
+      it {
+        is_expected.to contain_postgresql__server__config_entry('archive_command').with(
+          value: 'pgbackrest --stanza=psql archive-push %p',
+        )
+      }
+    end
+
+    context 'with a custom cluster name' do
+      let(:params) do
+        {
+          hostname: 'psql',
+          cluster: 'main_cluster',
+          version: '14',
+        }
+      end
+
+      it {
+        is_expected.to contain_postgresql__server__config_entry('archive_command').with(
+          value: 'pgbackrest --stanza=main_cluster archive-push %p',
+        )
+      }
+    end
+
+    context 'when manage_archive_cmd is disabled' do
+      let(:params) do
+        {
+          hostname: 'psql',
+          manage_archive_cmd: false,
+          version: '14',
+        }
+      end
+
+      it { is_expected.not_to contain_postgresql__server__config_entry('archive_mode') }
+      it { is_expected.not_to contain_postgresql__server__config_entry('archive_command') }
+    end
+  end
+
   context 'exporting host ssh key' do
     let(:params) do
       {

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -204,7 +204,7 @@ describe 'pgbackrest::stanza' do
 
     it {
       is_expected.to contain_postgresql__server__database('backup').with(
-        { 'owner' => 'backup' },
+        { 'owner' => 'pgbackup' },
       )
     }
   end

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -58,7 +58,7 @@ describe 'pgbackrest::stanza' do
   context 'manage ssh keys' do
     let(:params) do
       {
-        id: 'psql',
+        hostname: 'psql',
         manage_ssh_keys: true,
         ssh_key_type: 'ed25519',
         version: '14',
@@ -110,7 +110,7 @@ describe 'pgbackrest::stanza' do
             incr: {},
           },
         },
-        id: 'psql',
+        hostname: 'psql',
         port: 5433,
         db_name: 'pg_db',
         db_user:  'pg_user',
@@ -134,7 +134,7 @@ describe 'pgbackrest::stanza' do
             incr: {},
           },
         },
-        id: 'psql',
+        hostname: 'psql',
         port: 5433,
         db_name: 'pg_db',
         db_user:  'pg_user',
@@ -163,7 +163,7 @@ describe 'pgbackrest::stanza' do
   context 'exporting host ssh key' do
     let(:params) do
       {
-        id: 'psql',
+        hostname: 'psql',
         manage_host_keys: true,
         backup_dir: '/backup',
         version: '14',
@@ -188,7 +188,7 @@ describe 'pgbackrest::stanza' do
             full: {},
           },
         },
-        id: 'psql',
+        hostname: 'psql',
         manage_ssh_keys: false,
         manage_host_keys: false,
         version: '14',

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -63,22 +63,23 @@ describe 'pgbackrest::stanza' do
         ssh_key_type: 'ed25519',
         version: '14',
         db_path: '/var/lib/postgresql',
-        backup_user: 'backup'
+        user: 'pgbackup',
+        ssh_user: 'pgbackup',
       }
     end
 
     it 'generates ssh key pair, if missing' do
-      is_expected.to contain_exec('pgbackrest-generate-ssh-key_postgres').with(
-        command: 'su - postgres -c "ssh-keygen -t ed25519 -q -N \'\' -f /var/lib/postgresql/.ssh/id_ed25519"',
+      is_expected.to contain_exec('pgbackrest-generate-ssh-key_pgbackup').with(
+        command: 'su - pgbackup -c "ssh-keygen -t ed25519 -q -N \'\' -f /var/lib/postgresql/.ssh/id_ed25519"',
       )
     end
 
     it {
-      expect(exported_resources).to contain_ssh_authorized_key('postgres-psql.localhost')
+      expect(exported_resources).to contain_ssh_authorized_key('pgbackup-psql.localhost')
         .with(
-          user: 'backup',
+          user: 'pgbackup',
           type: 'ssh-ed25519',
-          key: 'AAAABBBBCC1lZDI1NTE5AAAAIN1UTKrM47QYBXJg0cIgrausN4o93I17AIj4K3i+5yS4',
+          key: 'AAAAC3NzaC1lZDI1NTE5AAAAIN1UTKrM47QYBXJg0cIgrausN4o93I17AIj4K3i+5yS4',
           tag: ['pgbackrest-common'],
         )
     }
@@ -86,15 +87,15 @@ describe 'pgbackrest::stanza' do
     it {
       is_expected.to contain_file('/var/cache/pgbackrest')
         .with(ensure: 'directory',
-            owner: 'postgres',
-            group: 'postgres')
+            owner: 'pgbackup',
+            group: 'pgbackup')
     }
 
     it {
       is_expected.to contain_ini_setting('pgbackrest-stanza').with(
         {
           ensure: 'present',
-          setting: 'postgres', value: '/var/lib/postgresql/.ssh/id_ed25519.pub',
+          setting: 'pgbackup', value: '/var/lib/postgresql/.ssh/id_ed25519.pub',
           path: '/var/cache/pgbackrest/exported_keys.ini'
         },
       )

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -6,4 +6,5 @@ networking:
   ip: "172.16.254.254"
   ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
   mac: "AA:AA:AA:AA:AA:AA"
+  hostname: psql
 is_pe: false

--- a/spec/defines/cron_backup_spec.rb
+++ b/spec/defines/cron_backup_spec.rb
@@ -8,7 +8,7 @@ describe 'pgbackrest::cron_backup' do
   let(:facts) { os_facts }
   let(:params) do
     {
-      id: 'psql01a',
+      hostname: 'psql01a',
       repo: 1,
       cluster: 'psql01',
       host_group: 'common',


### PR DESCRIPTION
- Use by default `pgbackup` user instead of `postgres` user
- manage `archive_command` config in postgresql server
- Grant `pg_read_all_settings`