### PR TITLE
Remote backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ pgbackrest::repository::config:
 
 All members of a PostgreSQL cluster share one stanza. Set the same `cluster`
 name on every member and give each one a unique `id` (the pg index used in the
-repository configuration). The member with `id: 1` is considered the primary
-and is the only one exporting per-cluster resources (backup cron jobs and the
-`stanza-create` command); this can be overridden with the `primary` parameter.
+repository configuration). The primary is detected at runtime via the
+`pgbackrest.in_recovery` fact (`SELECT pg_is_in_recovery()`), so the role
+follows failovers automatically; while PostgreSQL is not running yet (e.g.
+initial deployment) the member with `id: 1` is assumed to be the primary.
+Only the primary exports per-cluster resources (backup cron jobs and the
+`stanza-create` command); detection can be overridden with the `primary`
+parameter.
 
 Primary (psql01a):
 ```yaml

--- a/README.md
+++ b/README.md
@@ -47,6 +47,57 @@ pgbackrest::repository::config:
     compress-type: lz4
 ```
 
+## Primary with replicas (standby servers)
+
+All members of a PostgreSQL cluster share one stanza. Set the same `cluster`
+name on every member and give each one a unique `id` (the pg index used in the
+repository configuration). The member with `id: 1` is considered the primary
+and is the only one exporting per-cluster resources (backup cron jobs and the
+`stanza-create` command); this can be overridden with the `primary` parameter.
+
+Primary (psql01a):
+```yaml
+pgbackrest::stanza::cluster: psql01
+pgbackrest::stanza::id: 1
+pgbackrest::stanza::backups:
+  eu-west:
+    incr:
+      hour: 3
+```
+
+Standby (psql01b) — declare the same `backups` host groups (this assigns the
+repositories; schedules are only exported by the primary):
+```yaml
+pgbackrest::stanza::cluster: psql01
+pgbackrest::stanza::id: 2
+pgbackrest::stanza::backups:
+  eu-west:
+    incr:
+      hour: 3
+```
+
+Each member exports its own `conf.d/<cluster>-<hostname>.conf` file to the
+repository containing only its `pg<id>-*` options. pgBackRest merges all files
+in `conf.d`, so the repository ends up with a single stanza section:
+
+```ini
+[psql01]
+pg1-host = psql01a.example.com
+...
+pg2-host = psql01b.example.com
+...
+```
+
+To take backups from the standby instead of the primary, set
+`backup-standby: 'y'` in the repository's `global` config section.
+
+Caveats:
+- Role passwords are replicated from the primary, so when `manage_pgpass` is
+  enabled set the same `db_password` (or `seed`) on all members, otherwise
+  the standby exports a `.pgpass` entry with a password that doesn't match.
+- Remove any hand-managed stanza section for the same cluster from the
+  repository configuration, otherwise pgBackRest may see duplicated options.
+
 ## How Does This Work
 
 ### pgbackrest::stanza

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ include pgbackrest::repository
 
 repository config:
 ```yaml
+pgbackrest::repository::host_group: eu-west
 pgbackrest::repository::config:
   global:
     repo1-path: /backup/pgbackrest

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ pgbackrest::stanza::backups:
       hour: 3
 ```
 
+When cluster members follow a `<name><NN><member>` naming convention
+(psql01a, psql01b, ...), the `pgbackrest::instance_id` function derives the
+member id from the hostname, so it doesn't have to be maintained per host in
+Hiera. Since Hiera data cannot call functions, wire it up in a profile:
+
+```puppet
+class profile::pgbackrest_stanza {
+  class { 'pgbackrest::stanza':
+    id => pgbackrest::instance_id($facts['networking']['hostname']),
+    # psql01a.de -> 1, psql01b.de -> 2, psql02a.de -> 1
+    # hostnames without a member letter (psql01) -> 1
+  }
+}
+```
+
 Each member exports its own `conf.d/<cluster>-<hostname>.conf` file to the
 repository containing only its `pg<id>-*` options. pgBackRest merges all files
 in `conf.d`, so the repository ends up with a single stanza section:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ pgbackrest::repository::config:
 
 All members of a PostgreSQL cluster share one stanza. Set the same `cluster`
 name on every member and give each one a unique `id` (the pg index used in the
-repository configuration). The primary is detected at runtime via the
+repository configuration). pgBackRest requires `pg1-*` options to be present:
+repository-side commands (`stanza-create`, `backup`) fail with
+`command requires option: pg1-path` when no member exports id 1, so every
+cluster must contain a managed member with `id` 1 — if the only member's
+hostname would derive a higher id (e.g. a leftover `b` node after
+decommissioning the `a` node), set `id: 1` explicitly. The primary is detected at runtime via the
 `pgbackrest.in_recovery` fact (`SELECT pg_is_in_recovery()`), so the role
 follows failovers automatically; while PostgreSQL is not running yet (e.g.
 initial deployment) the member with `id: 1` is assumed to be the primary.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -678,13 +678,13 @@ Default value: `$facts['networking']['hostname']`
 
 ##### <a name="-pgbackrest--stanza--id"></a>`id`
 
-Data type: `Integer[1,256]`
+Data type: `Optional[Integer[1,256]]`
 
 Unique number of this instance within the cluster, used as the pg index
 (`pg<id>-*` options) in the repository configuration. The primary should use 1,
 each replica a distinct higher number.
 
-Default value: `1`
+Default value: `undef`
 
 ##### <a name="-pgbackrest--stanza--cluster"></a>`cluster`
 
@@ -697,13 +697,15 @@ Default value: `undef`
 
 ##### <a name="-pgbackrest--stanza--primary"></a>`primary`
 
-Data type: `Boolean`
+Data type: `Optional[Boolean]`
 
 Whether this instance exports per-cluster singleton resources
 (stanza-create command, backup cron jobs). Exactly one member of the cluster
-must be primary. Defaults to `true` when `id` is 1.
+must be primary. When unset, the role is detected at runtime from the
+`pgbackrest.in_recovery` fact (`SELECT pg_is_in_recovery()`), so it follows
+failovers; before PostgreSQL is up it falls back to `true` when `id` is 1.
 
-Default value: `$id == 1`
+Default value: `undef`
 
 ##### <a name="-pgbackrest--stanza--repo"></a>`repo`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -682,7 +682,12 @@ Data type: `Optional[Integer[1,256]]`
 
 Unique number of this instance within the cluster, used as the pg index
 (`pg<id>-*` options) in the repository configuration. The primary should use 1,
-each replica a distinct higher number.
+each replica a distinct higher number. When unset it is derived from the
+hostname suffix (see `pgbackrest::instance_id`), or defaults to 1 when no
+`cluster` is set. NOTE: pgBackRest requires `pg1-*` options to exist —
+repository-side commands (stanza-create, backup) fail without a member
+with id 1, so a cluster whose only managed member would derive a higher
+id must set `id: 1` explicitly.
 
 Default value: `undef`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -26,6 +26,7 @@
 
 ### Functions
 
+* [`pgbackrest::instance_id`](#pgbackrest--instance_id): Derives the cluster member id from a hostname suffix letter, so that cluster members named by the `<cluster><NN><member>` convention get a st
 * [`pgbackrest::ssh_key_path`](#pgbackrest--ssh_key_path): https://github.com/puppetlabs/puppet-specifications/blob/master/language/func-api.md#the-4x-api
 
 ### Data types
@@ -1059,6 +1060,50 @@ Unix groups to which the $user will belong
 Default value: `[]`
 
 ## Functions
+
+### <a name="pgbackrest--instance_id"></a>`pgbackrest::instance_id`
+
+Type: Ruby 4.x API
+
+Derives the cluster member id from a hostname suffix letter, so that
+cluster members named by the `<cluster><NN><member>` convention get
+a stable pg index: psql01a -> 1, psql01b -> 2, psql02a -> 1.
+
+#### Examples
+
+##### 
+
+```puppet
+pgbackrest::instance_id('psql01a.de') # => 1
+pgbackrest::instance_id('psql01b.de') # => 2
+pgbackrest::instance_id('psql02a.de') # => 1
+```
+
+#### `pgbackrest::instance_id(String[1] $hostname)`
+
+Derives the cluster member id from a hostname suffix letter, so that
+cluster members named by the `<cluster><NN><member>` convention get
+a stable pg index: psql01a -> 1, psql01b -> 2, psql02a -> 1.
+
+Returns: `Integer[1,26]` Position in the alphabet of the letter following the trailing digits
+of the first dot-separated label ('a' => 1, 'b' => 2, ...).
+Returns 1 when the hostname has no such suffix (standalone server).
+
+##### Examples
+
+###### 
+
+```puppet
+pgbackrest::instance_id('psql01a.de') # => 1
+pgbackrest::instance_id('psql01b.de') # => 2
+pgbackrest::instance_id('psql02a.de') # => 1
+```
+
+##### `hostname`
+
+Data type: `String[1]`
+
+Host name or FQDN, e.g. 'psql01b' or 'psql01b.de.example.com'
 
 ### <a name="pgbackrest--ssh_key_path"></a>`pgbackrest::ssh_key_path`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -285,6 +285,8 @@ The following parameters are available in the `pgbackrest::repository` class:
 
 * [`fqdn`](#-pgbackrest--repository--fqdn)
 * [`host_group`](#-pgbackrest--repository--host_group)
+* [`repo`](#-pgbackrest--repository--repo)
+* [`ssh_port`](#-pgbackrest--repository--ssh_port)
 * [`backup_dir`](#-pgbackrest--repository--backup_dir)
 * [`hba_entry_order`](#-pgbackrest--repository--hba_entry_order)
 * [`db_name`](#-pgbackrest--repository--db_name)
@@ -332,6 +334,22 @@ Data type: `String`
 The name of this backup repository
 
 Default value: `$pgbackrest::host_group`
+
+##### <a name="-pgbackrest--repository--repo"></a>`repo`
+
+Data type: `Integer[1,256]`
+
+Repository integer ID, matches the `repo` parameter used on the stanza (DB) side
+
+Default value: `1`
+
+##### <a name="-pgbackrest--repository--ssh_port"></a>`ssh_port`
+
+Data type: `Integer`
+
+ssh port used by DB instances to connect to this repository
+
+Default value: `22`
 
 ##### <a name="-pgbackrest--repository--backup_dir"></a>`backup_dir`
 
@@ -1023,7 +1041,7 @@ Data type: `Array[String]`
 
 Unix groups to which the $user will belong
 
-Default value: `['postgres']`
+Default value: `[]`
 
 ## Functions
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -637,6 +637,7 @@ The following parameters are available in the `pgbackrest::stanza` class:
 * [`backup_dir`](#-pgbackrest--stanza--backup_dir)
 * [`spool_dir`](#-pgbackrest--stanza--spool_dir)
 * [`backups`](#-pgbackrest--stanza--backups)
+* [`config`](#-pgbackrest--stanza--config)
 * [`ssh_user`](#-pgbackrest--stanza--ssh_user)
 * [`ssh_port`](#-pgbackrest--stanza--ssh_port)
 * [`log_level_console`](#-pgbackrest--stanza--log_level_console)
@@ -824,6 +825,15 @@ Data type: `Optional[Hash]`
 
 
 Default value: `undef`
+
+##### <a name="-pgbackrest--stanza--config"></a>`config`
+
+Data type: `Hash[String, Hash]`
+
+Options written to /etc/pgbackrest/pgbackrest.conf, keyed by section,
+e.g. `{ 'global' => { 'archive-async' => 'y', 'process-max' => 8 } }`
+
+Default value: `{}`
 
 ##### <a name="-pgbackrest--stanza--ssh_user"></a>`ssh_user`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -31,6 +31,7 @@
 ### Data types
 
 * [`Pgbackrest::BackupType`](#Pgbackrest--BackupType)
+* [`Pgbackrest::CompressLevel`](#Pgbackrest--CompressLevel): Compression level, negative values are supported by zst (valid range: -7 to 22)
 * [`Pgbackrest::CompressType`](#Pgbackrest--CompressType)
 * [`Pgbackrest::HostKey`](#Pgbackrest--HostKey): ssh host keys
 * [`Pgbackrest::Hour`](#Pgbackrest--Hour)
@@ -193,7 +194,7 @@ Data type: `String`
 
 DB role for backup operations
 
-Default value: `'pgbackup'`
+Default value: `'postgres'`
 
 ##### <a name="-pgbackrest--backup_user"></a>`backup_user`
 
@@ -620,6 +621,7 @@ The following parameters are available in the `pgbackrest::stanza` class:
 * [`hostname`](#-pgbackrest--stanza--hostname)
 * [`id`](#-pgbackrest--stanza--id)
 * [`cluster`](#-pgbackrest--stanza--cluster)
+* [`primary`](#-pgbackrest--stanza--primary)
 * [`repo`](#-pgbackrest--stanza--repo)
 * [`host_group`](#-pgbackrest--stanza--host_group)
 * [`version`](#-pgbackrest--stanza--version)
@@ -677,7 +679,9 @@ Default value: `$facts['networking']['hostname']`
 
 Data type: `Integer[1,256]`
 
-unique number in the cluster
+Unique number of this instance within the cluster, used as the pg index
+(`pg<id>-*` options) in the repository configuration. The primary should use 1,
+each replica a distinct higher number.
 
 Default value: `1`
 
@@ -686,8 +690,19 @@ Default value: `1`
 Data type: `Optional[String]`
 
 Cluster name in case database has primary and some replicas.
+All members of the cluster must use the same value (it becomes the stanza name).
 
 Default value: `undef`
+
+##### <a name="-pgbackrest--stanza--primary"></a>`primary`
+
+Data type: `Boolean`
+
+Whether this instance exports per-cluster singleton resources
+(stanza-create command, backup cron jobs). Exactly one member of the cluster
+must be primary. Defaults to `true` when `id` is 1.
+
+Default value: `$id == 1`
 
 ##### <a name="-pgbackrest--stanza--repo"></a>`repo`
 
@@ -873,7 +888,7 @@ Data type: `Boolean`
 
 whether db role should be managed
 
-Default value: `true`
+Default value: `false`
 
 ##### <a name="-pgbackrest--stanza--manage_ssh_keys"></a>`manage_ssh_keys`
 
@@ -981,7 +996,7 @@ Default value: `'gz'`
 
 ##### <a name="-pgbackrest--stanza--compress_level"></a>`compress_level`
 
-Data type: `Optional[Integer[0,9]]`
+Data type: `Optional[Pgbackrest::CompressLevel]`
 
 
 
@@ -1082,6 +1097,12 @@ Data type: `Boolean`
 The Pgbackrest::BackupType data type.
 
 Alias of `Enum['full', 'incr', 'delta']`
+
+### <a name="Pgbackrest--CompressLevel"></a>`Pgbackrest::CompressLevel`
+
+Compression level, negative values are supported by zst (valid range: -7 to 22)
+
+Alias of `Integer[-7, 22]`
 
 ### <a name="Pgbackrest--CompressType"></a>`Pgbackrest::CompressType`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -209,7 +209,7 @@ Data type: `String`
 
 
 
-Default value: `'pgbackup'`
+Default value: `'postgres'`
 
 ##### <a name="-pgbackrest--backup_group"></a>`backup_group`
 

--- a/lib/facter/pgbackrest_ssh_keys.rb
+++ b/lib/facter/pgbackrest_ssh_keys.rb
@@ -39,6 +39,18 @@ Facter.add(:pgbackrest) do
         end
       end
     end
+
+    # Runtime role of the local PostgreSQL instance; absent when the server
+    # is not running (or psql is not installed), so Puppet can fall back to
+    # a static default.
+    if Facter::Core::Execution.which('psql')
+      out = Facter::Core::Execution.execute(
+        %(su - postgres -c "psql -t -A -c 'SELECT pg_is_in_recovery()'"),
+        on_fail: nil,
+      )
+      res['in_recovery'] = out.strip == 't' if out && ['t', 'f'].include?(out.strip)
+    end
+
     res
   end
 end

--- a/lib/puppet/functions/pgbackrest/instance_id.rb
+++ b/lib/puppet/functions/pgbackrest/instance_id.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Derives the cluster member id from a hostname suffix letter, so that
+# cluster members named by the `<cluster><NN><member>` convention get
+# a stable pg index: psql01a -> 1, psql01b -> 2, psql02a -> 1.
+Puppet::Functions.create_function(:"pgbackrest::instance_id") do
+  # @param hostname Host name or FQDN, e.g. 'psql01b' or 'psql01b.de.example.com'
+  # @return Position in the alphabet of the letter following the trailing digits
+  #   of the first dot-separated label ('a' => 1, 'b' => 2, ...).
+  #   Returns 1 when the hostname has no such suffix (standalone server).
+  # @example
+  #   pgbackrest::instance_id('psql01a.de') # => 1
+  #   pgbackrest::instance_id('psql01b.de') # => 2
+  #   pgbackrest::instance_id('psql02a.de') # => 1
+  dispatch :instance_id do
+    param 'String[1]', :hostname
+    return_type 'Integer[1,26]'
+  end
+
+  def instance_id(hostname)
+    label = hostname.split('.').first
+    m = label.downcase.match(%r{[0-9]+([a-z])$})
+    return 1 if m.nil?
+
+    (m[1].ord - 'a'.ord) + 1
+  end
+end

--- a/manifests/cron_backup.pp
+++ b/manifests/cron_backup.pp
@@ -23,7 +23,7 @@ define pgbackrest::cron_backup (
   Pgbackrest::Minute              $minute = 0,
   Pgbackrest::Month               $month = '*',
   Pgbackrest::Weekday             $weekday = '*',
-  Optional[Integer[0,9]]          $compress_level = undef,
+  Optional[Pgbackrest::CompressLevel] $compress_level = undef,
   Optional[Integer]               $archive_timeout = undef,
   Optional[Pgbackrest::Monthday]  $monthday = undef,
   Optional[String]                $binary = undef,

--- a/manifests/cron_backup.pp
+++ b/manifests/cron_backup.pp
@@ -2,6 +2,7 @@
 # A cron job is exported from a database server, but could be executed elsewhere.
 # Typically on a catalog (backup) server.
 define pgbackrest::cron_backup (
+  Integer[1,256]                  $id,
   String                          $hostname,
   String                          $cluster,
   Integer[1,256]                  $repo,
@@ -30,6 +31,7 @@ define pgbackrest::cron_backup (
 ) {
   @@cron { "pgbackrest_${backup_type}_${server_address}-${host_group}":
     command  => epp('pgbackrest/cron_backup.epp', {
+        id                => $id,
         hostname          => $hostname,
         repo              => $repo,
         cluster           => $cluster,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class pgbackrest (
   String               $package_ensure = 'present',
   String               $db_name = 'backup',
   String               $db_user = 'pgbackup',
-  String               $ssh_user = 'pgbackup',
+  String               $ssh_user = 'postgres',
   String               $backup_user = 'pgbackup',
   String               $backup_group = 'pgbackup',
   Stdlib::AbsolutePath $config_dir = '/etc/pgbackrest',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class pgbackrest (
   String               $package_name = 'pgbackrest',
   String               $package_ensure = 'present',
   String               $db_name = 'backup',
-  String               $db_user = 'pgbackup',
+  String               $db_user = 'postgres',
   String               $ssh_user = 'postgres',
   String               $backup_user = 'pgbackup',
   String               $backup_group = 'pgbackup',

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -152,7 +152,9 @@ class pgbackrest::repository (
     }
 
     # Add public ssh keys from DB instances as authorized keys
-    Ssh_authorized_key <<| tag == "pgbackrest-${host_group}-instance" |>>
+    Ssh_authorized_key <<| tag == "pgbackrest-${host_group}" |>> {
+      require => File["${backup_dir}/.ssh"],
+    }
   }
 
   if $manage_pgpass {

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -169,7 +169,12 @@ class pgbackrest::repository (
     File_line <<| tag == "pgbackrest-${host_group}" |>>
   }
 
-  Exec <<| tag == "pgbackrest_stanza_create-${host_group}" |>>
+  # Collect per-member cluster configs exported by pgbackrest::stanza.
+  # pgBackRest merges all files in conf.d, so members of the same cluster
+  # (primary + replicas) combine into a single stanza section. They must be
+  # in place before stanza-create runs.
+  File <<| tag == "pgbackrest-${host_group}" |>>
+  -> Exec <<| tag == "pgbackrest_stanza_create-${host_group}" |>>
 
   if $manage_host_keys {
     # Import db instances host keys
@@ -239,8 +244,6 @@ class pgbackrest::repository (
       show_diff => true,
       require   => File['/var/cache/pgbackrest'],
     }
-
-    Concat::Fragment <<| tag == "pgbackrest-repository-${host_group}" |>>
 
     $_home = $user_home ? {
       undef   => $ssh_user == 'postgres' ? {

--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -4,6 +4,8 @@
 #
 # @param fqdn
 # @param host_group The name of this backup repository
+# @param repo Repository integer ID, matches the `repo` parameter used on the stanza (DB) side
+# @param ssh_port ssh port used by DB instances to connect to this repository
 # @param backup_dir Directory for storing backups
 # @param hba_entry_order
 # @param db_name
@@ -42,6 +44,8 @@
 #   include pgbackrest::repository
 class pgbackrest::repository (
   String                             $fqdn = $facts['networking']['fqdn'],
+  Integer[1,256]                     $repo = 1,
+  Integer                            $ssh_port = 22,
   Stdlib::AbsolutePath               $backup_dir = $pgbackrest::backup_dir,
   Stdlib::AbsolutePath               $spool_dir = $pgbackrest::spool_dir,
   Stdlib::AbsolutePath               $config_subdir = $pgbackrest::config_subdir,
@@ -260,6 +264,35 @@ class pgbackrest::repository (
         target => "${_home}/.ssh/authorized_keys",
       }
     }
+  }
+
+  # Export this repository's connection details so DB instances in
+  # host_group can reach it directly, written to their pgbackrest.conf [global] section.
+  @@ini_setting { "repo${repo}-host-${fqdn}":
+    ensure  => present,
+    path    => "${config_dir}/${config_file}",
+    section => 'global',
+    setting => "repo${repo}-host",
+    value   => $fqdn,
+    tag     => "pgbackrest-repository-${host_group}",
+  }
+
+  @@ini_setting { "repo${repo}-host-user-${fqdn}":
+    ensure  => present,
+    path    => "${config_dir}/${config_file}",
+    section => 'global',
+    setting => "repo${repo}-host-user",
+    value   => $user,
+    tag     => "pgbackrest-repository-${host_group}",
+  }
+
+  @@ini_setting { "repo${repo}-host-port-${fqdn}":
+    ensure  => present,
+    path    => "${config_dir}/${config_file}",
+    section => 'global',
+    setting => "repo${repo}-host-port",
+    value   => $ssh_port,
+    tag     => "pgbackrest-repository-${host_group}",
   }
 
   if $manage_cron {

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -3,8 +3,14 @@
 # Manages configuration for postgresql database backup
 #
 # @param hostname Unique identifier
-# @param id unique number in the cluster
+# @param id Unique number of this instance within the cluster, used as the pg index
+#   (`pg<id>-*` options) in the repository configuration. The primary should use 1,
+#   each replica a distinct higher number.
 # @param cluster Cluster name in case database has primary and some replicas.
+#   All members of the cluster must use the same value (it becomes the stanza name).
+# @param primary Whether this instance exports per-cluster singleton resources
+#   (stanza-create command, backup cron jobs). Exactly one member of the cluster
+#   must be primary. Defaults to `true` when `id` is 1.
 # @param repo backup repository integer ID
 # @param host_group Default repository host group
 # @param version PostgreSQL major version, e.g. '16'
@@ -113,7 +119,8 @@ class pgbackrest::stanza (
   Enum['present', 'absent']          $user_ensure          = 'present',
   Optional[Stdlib::AbsolutePath]     $user_home            = undef,
   Optional[Integer]                  $uid                  = undef,
-  Array[String]                      $groups               = []
+  Array[String]                      $groups               = [],
+  Boolean                            $primary              = $id == 1,
 ) inherits pgbackrest {
   $_version = $version ? {
     undef   => lookup('postgresql::globals::version'),
@@ -315,16 +322,33 @@ class pgbackrest::stanza (
     require => File[$pgbackrest::config_subdir],
   }
 
-  # remote config on backup server
-  @@concat::fragment { "${pgbackrest::config_subdir}/${_cluster}.conf":
-    target  => "${pgbackrest::config_subdir}/${_cluster}.conf",
+  # Remote config on backup server: one file per cluster member, all declaring
+  # the same [cluster] section with disjoint pg<id>-* keys. pgBackRest merges
+  # every file in conf.d, so primary and replicas end up in a single stanza.
+  $remote_conf = {
+    "pg${id}-host"      => $address,
+    "pg${id}-host-user" => $ssh_user,
+    "pg${id}-path"      => "${db_path}/${_version}/${db_cluster}",
+    "pg${id}-port"      => String($port),
+    "pg${id}-database"  => $db_name,
+    "pg${id}-user"      => $db_user,
+  }
+
+  $_remote_conf = $ssh_port == 22 ? {
+    true  => $remote_conf,
+    false => $remote_conf + { "pg${id}-host-port" => String($ssh_port) },
+  }
+
+  @@file { "${pgbackrest::config_subdir}/${_cluster}-${hostname}.conf":
+    ensure  => file,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
     content => epp("${module_name}/cluster.epp", {
         'cluster' => $_cluster,
-        'config'  => $db_conf,
+        'config'  => $_remote_conf,
     }),
-    order   => 50,
-    tag     => "pgbackrest-repository-${host_group}",
-    require => File[$pgbackrest::config_subdir],
+    tag     => $tags,
   }
 
   if $manage_archive_cmd {
@@ -340,16 +364,20 @@ class pgbackrest::stanza (
 
   if !empty($backups) {
     $backups.each |String $host_group, Hash $config| {
-      @@exec { "pgbackrest_stanza_create_${address}-${host_group}":
-        command => "pgbackrest stanza-create --stanza=${_cluster}",
-        path    => ['/usr/bin', '/bin'],
-        cwd     => $backup_dir,
-        # `pgbackrest info` takes no locks, so an already-created stanza is
-        # skipped even while a backup or archive-push holds the stanza lock
-        onlyif  => "pgbackrest info --stanza=${_cluster} | grep -q 'missing stanza'",
-        tag     => "pgbackrest_stanza_create-${host_group}",
-        user    => $user, # note: error output might not be captured
-        require => [Package[$pgbackrest::package_name], Class['Pgbackrest::Config']],
+      # stanza-create is per-cluster, exporting it from every member would
+      # race for the stanza lock on the repository
+      if $primary {
+        @@exec { "pgbackrest_stanza_create_${address}-${host_group}":
+          command => "pgbackrest stanza-create --stanza=${_cluster}",
+          path    => ['/usr/bin', '/bin'],
+          cwd     => $backup_dir,
+          # `pgbackrest info` takes no locks, so an already-created stanza is
+          # skipped even while a backup or archive-push holds the stanza lock
+          onlyif  => "pgbackrest info --stanza=${_cluster} | grep -q 'missing stanza'",
+          tag     => "pgbackrest_stanza_create-${host_group}",
+          user    => $user, # note: error output might not be captured
+          require => [Package[$pgbackrest::package_name], Class['Pgbackrest::Config']],
+        }
       }
 
       # Collect resources exported by pgbackrest::repository
@@ -373,7 +401,9 @@ class pgbackrest::stanza (
         Sshkey <<| tag == "pgbackrest-repository-${host_group}" |>>
       }
 
-      if $manage_cron {
+      # backups run per-stanza (pgBackRest picks the primary or a standby
+      # itself), so only one member exports the cron jobs
+      if $manage_cron and $primary {
         $config.each |$backup_type, $schedule| {
           # declare cron job, use defaults from stanza
           create_resources(pgbackrest::cron_backup, { "cron_backup-${host_group}-${address}-${backup_type}" => $schedule }, {

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -233,7 +233,7 @@ class pgbackrest::stanza (
       file { $_ssh_dir:
         ensure => directory,
         owner  => $ssh_user,
-        mode   => '0600',
+        mode   => '0700',
       }
     }
 

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -5,7 +5,12 @@
 # @param hostname Unique identifier
 # @param id Unique number of this instance within the cluster, used as the pg index
 #   (`pg<id>-*` options) in the repository configuration. The primary should use 1,
-#   each replica a distinct higher number.
+#   each replica a distinct higher number. When unset it is derived from the
+#   hostname suffix (see `pgbackrest::instance_id`), or defaults to 1 when no
+#   `cluster` is set. NOTE: pgBackRest requires `pg1-*` options to exist —
+#   repository-side commands (stanza-create, backup) fail without a member
+#   with id 1, so a cluster whose only managed member would derive a higher
+#   id must set `id: 1` explicitly.
 # @param cluster Cluster name in case database has primary and some replicas.
 #   All members of the cluster must use the same value (it becomes the stanza name).
 # @param primary Whether this instance exports per-cluster singleton resources
@@ -124,8 +129,14 @@ class pgbackrest::stanza (
   Array[String]                      $groups               = [],
   Optional[Boolean]                  $primary              = undef,
 ) inherits pgbackrest {
+  # pgBackRest requires pg1-* to be defined for repository-side commands
+  # (stanza-create, backup), so a standalone instance must always be pg1;
+  # the hostname suffix is only meaningful within a named cluster.
   $_id = $id ? {
-    undef   => pgbackrest::instance_id($facts['networking']['hostname']),
+    undef   => $cluster ? {
+      undef   => 1,
+      default => pgbackrest::instance_id($facts['networking']['hostname']),
+    },
     default => $id,
   }
 

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -39,6 +39,9 @@
 #  Path where transient data is stored (should be on local filesystem)
 #  Default: /var/spool/pgbackrest
 # @param backups
+# @param config
+#   Options written to /etc/pgbackrest/pgbackrest.conf, keyed by section,
+#   e.g. `{ 'global' => { 'archive-async' => 'y', 'process-max' => 8 } }`
 # @param ssh_user
 #   user used for ssh connection to the DB instance
 # @param ssh_port
@@ -114,6 +117,7 @@ class pgbackrest::stanza (
   Stdlib::AbsolutePath               $log_dir              = $pgbackrest::log_dir,
   Postgresql::Pg_password_encryption $password_encryption  = $pgbackrest::password_encryption,
   Optional[Hash]                     $backups              = undef,
+  Hash[String, Hash]                 $config               = {},
   Pgbackrest::LogLevel               $log_level_console    = 'warn',
   Pgbackrest::LogLevel               $log_level_file       = 'info',
   Pgbackrest::CompressType           $compress_type        = 'gz',
@@ -328,7 +332,9 @@ class pgbackrest::stanza (
     }
   }
 
-  include pgbackrest::config
+  class { 'pgbackrest::config':
+    config => $config,
+  }
 
   $db_conf = {
     'log-level-console' => $log_level_console,

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -295,12 +295,9 @@ class pgbackrest::stanza (
 
   $db_conf = {
     'log-level-console' => $log_level_console,
-    "pg${id}-host" => $address,
     "pg${id}-path" => "${db_path}/${_version}/${db_cluster}",
-    "pg${id}-port" => $port,
     "pg${id}-database" => $db_name,
     "pg${id}-user" => $db_user,
-    "pg${id}-host-user" => $ssh_user,
   }
 
   # local config

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -350,6 +350,12 @@ class pgbackrest::stanza (
       # Collect resources exported by pgbackrest::repository
       Postgresql::Server::Pg_hba_rule <<| tag == "pgbackrest-${host_group}" |>>
 
+      # Import repository connection details (repo${repo}-host, repo${repo}-host-user,
+      # repo${repo}-host-port) into this instance's pgbackrest.conf
+      Ini_setting <<| tag == "pgbackrest-repository-${host_group}" |>> {
+        require => Class['Pgbackrest::Config'],
+      }
+
       if $manage_ssh_keys {
         # Import public key from backup server as authorized
         Ssh_authorized_key <<| tag == "pgbackrest-repository-${host_group}" |>> {

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -375,6 +375,7 @@ class pgbackrest::stanza (
         $config.each |$backup_type, $schedule| {
           # declare cron job, use defaults from stanza
           create_resources(pgbackrest::cron_backup, { "cron_backup-${host_group}-${address}-${backup_type}" => $schedule }, {
+              id                   => $id,
               hostname             => $hostname,
               repo                 => $repo,
               cluster              => $_cluster,

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -112,8 +112,8 @@ class pgbackrest::stanza (
   String                             $user_shell           = '/bin/bash',
   Enum['present', 'absent']          $user_ensure          = 'present',
   Optional[Stdlib::AbsolutePath]     $user_home            = undef,
-  Optional[Integer]                  $uid = undef,
-  Array[String]                      $groups               = ['postgres']
+  Optional[Integer]                  $uid                  = undef,
+  Array[String]                      $groups               = []
 ) inherits pgbackrest {
   $_version = $version ? {
     undef   => lookup('postgresql::globals::version'),
@@ -147,6 +147,12 @@ class pgbackrest::stanza (
     default => $user_home,
   }
 
+  # home of the account used for the ssh connection (may differ from $user/$_home)
+  $_ssh_home = $ssh_user == 'postgres' ? {
+    true  => '/var/lib/postgresql',
+    false => "/home/${ssh_user}",
+  }
+
   if $manage_user {
     group { $group:
       ensure => $user_ensure,
@@ -157,10 +163,15 @@ class pgbackrest::stanza (
       uid        => $uid,
       gid        => $group, # a primary group
       home       => $_home,
-      groups     => $groups,
       managehome => $manage_user_home,
       shell      => $user_shell,
       require    => Group[$group],
+    }
+
+    if !empty($groups) {
+      User<| title == $user |> {
+        groups => $groups,
+      }
     }
   }
 
@@ -217,19 +228,19 @@ class pgbackrest::stanza (
   }
 
   if $manage_ssh_keys {
-    file { "${_home}/.ssh":
+    file { "${_ssh_home}/.ssh":
       ensure => directory,
-      owner  => $user,
+      owner  => $ssh_user,
       mode   => '0600',
     }
 
-    $privkey_path = pgbackrest::ssh_key_path("${_home}/.ssh", $ssh_key_type, false)
-    $pubkey_path = pgbackrest::ssh_key_path("${_home}/.ssh", $ssh_key_type, true)
+    $privkey_path = pgbackrest::ssh_key_path("${_ssh_home}/.ssh", $ssh_key_type, false)
+    $pubkey_path = pgbackrest::ssh_key_path("${_ssh_home}/.ssh", $ssh_key_type, true)
     exec { "pgbackrest-generate-ssh-key_${ssh_user}":
       command => "su - ${ssh_user} -c \"ssh-keygen -t ${ssh_key_type} -q -N '' -f ${privkey_path}\"",
       path    => ['/usr/bin'],
       onlyif  => "test ! -f ${privkey_path}",
-      require => File["${_home}/.ssh"],
+      require => File["${_ssh_home}/.ssh"],
     }
 
     file { '/var/cache/pgbackrest':
@@ -322,6 +333,7 @@ class pgbackrest::stanza (
     }
 
     postgresql::server::config_entry { 'archive_command':
+      # command is executed by postgres user
       value => "pgbackrest --stanza=${_cluster} archive-push %p", # reload
     }
   }

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -10,7 +10,9 @@
 #   All members of the cluster must use the same value (it becomes the stanza name).
 # @param primary Whether this instance exports per-cluster singleton resources
 #   (stanza-create command, backup cron jobs). Exactly one member of the cluster
-#   must be primary. Defaults to `true` when `id` is 1.
+#   must be primary. When unset, the role is detected at runtime from the
+#   `pgbackrest.in_recovery` fact (`SELECT pg_is_in_recovery()`), so it follows
+#   failovers; before PostgreSQL is up it falls back to `true` when `id` is 1.
 # @param repo backup repository integer ID
 # @param host_group Default repository host group
 # @param version PostgreSQL major version, e.g. '16'
@@ -120,11 +122,20 @@ class pgbackrest::stanza (
   Optional[Stdlib::AbsolutePath]     $user_home            = undef,
   Optional[Integer]                  $uid                  = undef,
   Array[String]                      $groups               = [],
-  Boolean                            $primary              = $id == 1,
+  Optional[Boolean]                  $primary              = undef,
 ) inherits pgbackrest {
   $_id = $id ? {
     undef   => pgbackrest::instance_id($facts['networking']['hostname']),
     default => $id,
+  }
+
+  if $primary !~ Undef {
+    $_primary = $primary
+  } elsif 'pgbackrest' in $facts and 'in_recovery' in $facts['pgbackrest'] {
+    $_primary = !$facts['pgbackrest']['in_recovery']
+  } else {
+    # PostgreSQL not running yet (e.g. initial deployment)
+    $_primary = $_id == 1
   }
 
   $_version = $version ? {
@@ -371,7 +382,7 @@ class pgbackrest::stanza (
     $backups.each |String $host_group, Hash $config| {
       # stanza-create is per-cluster, exporting it from every member would
       # race for the stanza lock on the repository
-      if $primary {
+      if $_primary {
         @@exec { "pgbackrest_stanza_create_${address}-${host_group}":
           command => "pgbackrest stanza-create --stanza=${_cluster}",
           path    => ['/usr/bin', '/bin'],
@@ -408,7 +419,7 @@ class pgbackrest::stanza (
 
       # backups run per-stanza (pgBackRest picks the primary or a standby
       # itself), so only one member exports the cron jobs
-      if $manage_cron and $primary {
+      if $manage_cron and $_primary {
         $config.each |$backup_type, $schedule| {
           # declare cron job, use defaults from stanza
           create_resources(pgbackrest::cron_backup, { "cron_backup-${host_group}-${address}-${backup_type}" => $schedule }, {

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -228,10 +228,13 @@ class pgbackrest::stanza (
   }
 
   if $manage_ssh_keys {
-    file { "${_ssh_home}/.ssh":
-      ensure => directory,
-      owner  => $ssh_user,
-      mode   => '0600',
+    $_ssh_dir = "${_ssh_home}/.ssh"
+    unless defined(File[$_ssh_dir]) {
+      file { $_ssh_dir:
+        ensure => directory,
+        owner  => $ssh_user,
+        mode   => '0600',
+      }
     }
 
     $privkey_path = pgbackrest::ssh_key_path("${_ssh_home}/.ssh", $ssh_key_type, false)

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -104,7 +104,7 @@ class pgbackrest::stanza (
   Pgbackrest::LogLevel               $log_level_console    = 'warn',
   Pgbackrest::LogLevel               $log_level_file       = 'info',
   Pgbackrest::CompressType           $compress_type        = 'gz',
-  Optional[Integer[0,9]]             $compress_level       = undef,
+  Optional[Pgbackrest::CompressLevel] $compress_level       = undef,
   Optional[Integer[1,999]]           $process_max          = undef,
   Optional[Integer]                  $archive_timeout      = undef,
   Optional[Stdlib::AbsolutePath]     $binary               = undef,

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -342,9 +342,11 @@ class pgbackrest::stanza (
     $backups.each |String $host_group, Hash $config| {
       @@exec { "pgbackrest_stanza_create_${address}-${host_group}":
         command => "pgbackrest stanza-create --stanza=${_cluster}",
-        path    => ['/usr/bin'],
+        path    => ['/usr/bin', '/bin'],
         cwd     => $backup_dir,
-        #onlyif  => "test ! -d ${backup_dir}/backups/${_cluster}",
+        # `pgbackrest info` takes no locks, so an already-created stanza is
+        # skipped even while a backup or archive-push holds the stanza lock
+        onlyif  => "pgbackrest info --stanza=${_cluster} | grep -q 'missing stanza'",
         tag     => "pgbackrest_stanza_create-${host_group}",
         user    => $user, # note: error output might not be captured
         require => [Package[$pgbackrest::package_name], Class['Pgbackrest::Config']],

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -344,7 +344,7 @@ class pgbackrest::stanza (
     false => $remote_conf + { "pg${_id}-host-port" => String($ssh_port) },
   }
 
-  @@file { "${pgbackrest::config_subdir}/${_cluster}-${hostname}.conf":
+  @@file { "${pgbackrest::config_subdir}/${_cluster}-${_id}.conf":
     ensure  => file,
     owner   => $user,
     group   => $group,

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -83,7 +83,7 @@ class pgbackrest::stanza (
   Optional[String]                   $seed                 = undef,
   String                             $user                 = $pgbackrest::backup_user,
   String                             $group                = $pgbackrest::backup_group,
-  Boolean                            $manage_dbuser        = true,
+  Boolean                            $manage_dbuser        = false,
   Boolean                            $manage_ssh_keys      = $pgbackrest::manage_ssh_keys,
   Boolean                            $manage_host_keys     = $pgbackrest::manage_host_keys,
   Boolean                            $manage_pgpass        = $pgbackrest::manage_pgpass,

--- a/manifests/stanza.pp
+++ b/manifests/stanza.pp
@@ -74,7 +74,7 @@
 #   include pgbackrest::stanza
 class pgbackrest::stanza (
   String                             $hostname             = $facts['networking']['hostname'],
-  Integer[1,256]                     $id                   = 1,
+  Optional[Integer[1,256]]           $id                   = undef,
   Integer[1,256]                     $repo                 = 1,
   Optional[String]                   $cluster              = undef,
   String                             $host_group           = $pgbackrest::host_group,
@@ -122,6 +122,11 @@ class pgbackrest::stanza (
   Array[String]                      $groups               = [],
   Boolean                            $primary              = $id == 1,
 ) inherits pgbackrest {
+  $_id = $id ? {
+    undef   => pgbackrest::instance_id($facts['networking']['hostname']),
+    default => $id,
+  }
+
   $_version = $version ? {
     undef   => lookup('postgresql::globals::version'),
     default => $version
@@ -305,9 +310,9 @@ class pgbackrest::stanza (
 
   $db_conf = {
     'log-level-console' => $log_level_console,
-    "pg${id}-path" => "${db_path}/${_version}/${db_cluster}",
-    "pg${id}-database" => $db_name,
-    "pg${id}-user" => $db_user,
+    "pg${_id}-path" => "${db_path}/${_version}/${db_cluster}",
+    "pg${_id}-database" => $db_name,
+    "pg${_id}-user" => $db_user,
   }
 
   # local config
@@ -326,17 +331,17 @@ class pgbackrest::stanza (
   # the same [cluster] section with disjoint pg<id>-* keys. pgBackRest merges
   # every file in conf.d, so primary and replicas end up in a single stanza.
   $remote_conf = {
-    "pg${id}-host"      => $address,
-    "pg${id}-host-user" => $ssh_user,
-    "pg${id}-path"      => "${db_path}/${_version}/${db_cluster}",
-    "pg${id}-port"      => String($port),
-    "pg${id}-database"  => $db_name,
-    "pg${id}-user"      => $db_user,
+    "pg${_id}-host"      => $address,
+    "pg${_id}-host-user" => $ssh_user,
+    "pg${_id}-path"      => "${db_path}/${_version}/${db_cluster}",
+    "pg${_id}-port"      => String($port),
+    "pg${_id}-database"  => $db_name,
+    "pg${_id}-user"      => $db_user,
   }
 
   $_remote_conf = $ssh_port == 22 ? {
     true  => $remote_conf,
-    false => $remote_conf + { "pg${id}-host-port" => String($ssh_port) },
+    false => $remote_conf + { "pg${_id}-host-port" => String($ssh_port) },
   }
 
   @@file { "${pgbackrest::config_subdir}/${_cluster}-${hostname}.conf":
@@ -407,7 +412,7 @@ class pgbackrest::stanza (
         $config.each |$backup_type, $schedule| {
           # declare cron job, use defaults from stanza
           create_resources(pgbackrest::cron_backup, { "cron_backup-${host_group}-${address}-${backup_type}" => $schedule }, {
-              id                   => $id,
+              id                   => $_id,
               hostname             => $hostname,
               repo                 => $repo,
               cluster              => $_cluster,

--- a/spec/classes/grants_spec.rb
+++ b/spec/classes/grants_spec.rb
@@ -7,27 +7,290 @@ describe 'pgbackrest::grants' do
 
   let(:facts) { os_facts }
 
-  let(:params) do
-    {
-      db_user: 'backup',
-      db_name: 'backup',
-      version: '16',
-    }
-  end
-
   let :pre_condition do
     'include postgresql::server'
   end
 
-  it { is_expected.to compile }
+  shared_examples 'common backup grants' do
+    let(:db_user) { params[:db_user] }
+    let(:db_name) { params[:db_name] }
 
-  it {
-    is_expected.to contain_postgresql__server__grant_role("pg_read_all_settings_to_#{params[:db_user]}")
-      .with(group: 'pg_read_all_settings', role: params[:db_user])
-  }
+    it { is_expected.to compile }
 
-  it {
-    is_expected.to contain_postgresql_psql("grant_role:pg_read_all_settings_to_#{params[:db_user]}")
-      .with(command: "GRANT \"pg_read_all_settings\" TO \"#{params[:db_user]}\"")
-  }
+    it {
+      is_expected.to contain_postgresql__server__grant("pg_catalog_usage_to_#{db_user}").with(
+        db: db_name,
+        role: db_user,
+        privilege: 'USAGE',
+        object_type: 'SCHEMA',
+        object_name: 'pg_catalog',
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:pg_catalog_usage_to_#{db_user}").with(
+        command: "GRANT USAGE ON SCHEMA \"pg_catalog\" TO \"#{db_user}\"",
+        db: db_name,
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant_role("pg_read_all_settings_to_#{db_user}")
+        .with(group: 'pg_read_all_settings', role: db_user)
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant_role:pg_read_all_settings_to_#{db_user}")
+        .with(command: "GRANT \"pg_read_all_settings\" TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("current_setting-to-#{db_user}").with(
+        db: db_name,
+        role: db_user,
+        privilege: 'EXECUTE',
+        object_type: 'FUNCTION',
+        object_name: ['pg_catalog', 'current_setting'],
+        object_arguments: ['text'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:current_setting-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.current_setting(text) TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("set_config-to-#{db_user}").with(
+        db: db_name,
+        role: db_user,
+        privilege: 'EXECUTE',
+        object_type: 'FUNCTION',
+        object_name: ['pg_catalog', 'set_config'],
+        object_arguments: ['text', 'text', 'boolean'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:set_config-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.set_config(text,text,boolean) TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("pg_is_in_recovery-to-#{db_user}").with(
+        db: db_name,
+        role: db_user,
+        privilege: 'EXECUTE',
+        object_type: 'FUNCTION',
+        object_name: ['pg_catalog', 'pg_is_in_recovery'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:pg_is_in_recovery-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.pg_is_in_recovery() TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("pg_create_restore_point-to-#{db_user}").with(
+        object_name: ['pg_catalog', 'pg_create_restore_point'],
+        object_arguments: ['text'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:pg_create_restore_point-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.pg_create_restore_point(text) TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("pg_switch_wal-to-#{db_user}").with(
+        object_name: ['pg_catalog', 'pg_switch_wal'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:pg_switch_wal-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.pg_switch_wal() TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("pg_last_wal_replay_lsn-to-#{db_user}").with(
+        object_name: ['pg_catalog', 'pg_last_wal_replay_lsn'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:pg_last_wal_replay_lsn-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.pg_last_wal_replay_lsn() TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("txid_current-to-#{db_user}").with(
+        object_name: ['pg_catalog', 'txid_current'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:txid_current-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.txid_current() TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("txid_current_snapshot-to-#{db_user}").with(
+        object_name: ['pg_catalog', 'txid_current_snapshot'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:txid_current_snapshot-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.txid_current_snapshot() TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("txid_snapshot_xmax-to-#{db_user}").with(
+        object_name: ['pg_catalog', 'txid_snapshot_xmax'],
+        object_arguments: ['txid_snapshot'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:txid_snapshot_xmax-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.txid_snapshot_xmax(txid_snapshot) TO \"#{db_user}\"")
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant("pg_control_checkpoint-to-#{db_user}").with(
+        object_name: ['pg_catalog', 'pg_control_checkpoint'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql("grant:pg_control_checkpoint-to-#{db_user}")
+        .with(command: "GRANT EXECUTE ON FUNCTION pg_catalog.pg_control_checkpoint() TO \"#{db_user}\"")
+    }
+  end
+
+  context 'on PostgreSQL < 15 (pg_start_backup/pg_stop_backup)' do
+    let(:params) do
+      {
+        db_user: 'backup',
+        db_name: 'backup',
+        version: '14',
+      }
+    end
+
+    include_examples 'common backup grants'
+
+    it {
+      is_expected.to contain_postgresql__server__grant('pg_start_backup-to-backup').with(
+        db: 'backup',
+        role: 'backup',
+        privilege: 'EXECUTE',
+        object_type: 'FUNCTION',
+        object_name: ['pg_catalog', 'pg_start_backup'],
+        object_arguments: ['text', 'boolean', 'boolean'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql('grant:pg_start_backup-to-backup')
+        .with(command: 'GRANT EXECUTE ON FUNCTION pg_catalog.pg_start_backup(text,boolean,boolean) TO "backup"')
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant('pg_stop_backup-to-backup').with(
+        object_name: ['pg_catalog', 'pg_stop_backup'],
+        object_arguments: ['boolean', 'boolean'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql('grant:pg_stop_backup-to-backup')
+        .with(command: 'GRANT EXECUTE ON FUNCTION pg_catalog.pg_stop_backup(boolean,boolean) TO "backup"')
+    }
+
+    it { is_expected.not_to contain_postgresql__server__grant('pg_backup_start-to-backup') }
+    it { is_expected.not_to contain_postgresql__server__grant('pg_backup_stop-to-backup') }
+  end
+
+  context 'on PostgreSQL >= 15 (pg_backup_start/pg_backup_stop)' do
+    let(:params) do
+      {
+        db_user: 'backup',
+        db_name: 'backup',
+        version: '15',
+      }
+    end
+
+    include_examples 'common backup grants'
+
+    it {
+      is_expected.to contain_postgresql__server__grant('pg_backup_start-to-backup').with(
+        db: 'backup',
+        role: 'backup',
+        privilege: 'EXECUTE',
+        object_type: 'FUNCTION',
+        object_name: ['pg_catalog', 'pg_backup_start'],
+        object_arguments: ['text', 'boolean'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql('grant:pg_backup_start-to-backup')
+        .with(command: 'GRANT EXECUTE ON FUNCTION pg_catalog.pg_backup_start(text,boolean) TO "backup"')
+    }
+
+    it {
+      is_expected.to contain_postgresql__server__grant('pg_backup_stop-to-backup').with(
+        object_name: ['pg_catalog', 'pg_backup_stop'],
+        object_arguments: ['boolean'],
+      )
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql('grant:pg_backup_stop-to-backup')
+        .with(command: 'GRANT EXECUTE ON FUNCTION pg_catalog.pg_backup_stop(boolean) TO "backup"')
+    }
+
+    it { is_expected.not_to contain_postgresql__server__grant('pg_start_backup-to-backup') }
+    it { is_expected.not_to contain_postgresql__server__grant('pg_stop_backup-to-backup') }
+  end
+
+  context 'on PostgreSQL 16' do
+    let(:params) do
+      {
+        db_user: 'backup',
+        db_name: 'backup',
+        version: '16',
+      }
+    end
+
+    include_examples 'common backup grants'
+
+    it { is_expected.to contain_postgresql__server__grant('pg_backup_start-to-backup') }
+    it { is_expected.to contain_postgresql__server__grant('pg_backup_stop-to-backup') }
+  end
+
+  context 'with a custom db_user and db_name' do
+    let(:params) do
+      {
+        db_user: 'pgbackrest',
+        db_name: 'pgbackup',
+        version: '16',
+      }
+    end
+
+    include_examples 'common backup grants'
+
+    it {
+      is_expected.to contain_postgresql__server__grant('current_setting-to-pgbackrest')
+        .with(db: 'pgbackup', role: 'pgbackrest')
+    }
+
+    it {
+      is_expected.to contain_postgresql_psql('grant:current_setting-to-pgbackrest')
+        .with(command: 'GRANT EXECUTE ON FUNCTION pg_catalog.current_setting(text) TO "pgbackrest"')
+    }
+  end
 end

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -193,7 +193,7 @@ describe 'pgbackrest::repository' do
     it 'exports public ssh key' do
       expect(exported_resources).to contain_ssh_authorized_key('pgbackrest-psql.localhost')
         .with(
-          user: 'pgbackup',
+          user: 'postgres',
           type: 'ssh-ed25519',
           key: 'AAAAC3NzaC1lZDI1NTE5AAAAIN1UTKrM47QYBXJg0cIgrausN4o93I17AIj4K3i+5yS4',
         )

--- a/spec/classes/repository_spec.rb
+++ b/spec/classes/repository_spec.rb
@@ -225,4 +225,77 @@ describe 'pgbackrest::repository' do
       )
     }
   end
+
+  context 'exports repository connection details' do
+    let(:params) do
+      {
+        user: 'pgbackup',
+        host_group: 'common',
+      }
+    end
+
+    it 'exports repo1-host' do
+      expect(exported_resources).to contain_ini_setting('repo1-host-psql.localhost').with(
+        ensure: 'present',
+        path: '/etc/pgbackrest/pgbackrest.conf',
+        section: 'global',
+        setting: 'repo1-host',
+        value: 'psql.localhost',
+        tag: ['pgbackrest-repository-common'],
+      )
+    end
+
+    it 'exports repo1-host-user' do
+      expect(exported_resources).to contain_ini_setting('repo1-host-user-psql.localhost').with(
+        ensure: 'present',
+        path: '/etc/pgbackrest/pgbackrest.conf',
+        section: 'global',
+        setting: 'repo1-host-user',
+        value: 'pgbackup',
+        tag: ['pgbackrest-repository-common'],
+      )
+    end
+
+    it 'exports repo1-host-port' do
+      expect(exported_resources).to contain_ini_setting('repo1-host-port-psql.localhost').with(
+        ensure: 'present',
+        path: '/etc/pgbackrest/pgbackrest.conf',
+        section: 'global',
+        setting: 'repo1-host-port',
+        value: 22,
+        tag: ['pgbackrest-repository-common'],
+      )
+    end
+
+    context 'with a non-default repo id and ssh_port' do
+      let(:params) do
+        {
+          user: 'pgbackup',
+          host_group: 'offsite',
+          repo: 2,
+          ssh_port: 2222,
+        }
+      end
+
+      it 'exports repo2-host settings tagged for the matching host_group' do
+        expect(exported_resources).to contain_ini_setting('repo2-host-psql.localhost').with(
+          setting: 'repo2-host',
+          value: 'psql.localhost',
+          tag: ['pgbackrest-repository-offsite'],
+        )
+
+        expect(exported_resources).to contain_ini_setting('repo2-host-user-psql.localhost').with(
+          setting: 'repo2-host-user',
+          value: 'pgbackup',
+          tag: ['pgbackrest-repository-offsite'],
+        )
+
+        expect(exported_resources).to contain_ini_setting('repo2-host-port-psql.localhost').with(
+          setting: 'repo2-host-port',
+          value: 2222,
+          tag: ['pgbackrest-repository-offsite'],
+        )
+      end
+    end
+  end
 end

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -291,6 +291,7 @@ describe 'pgbackrest::stanza' do
             full: {},
           },
         },
+        id: 1,
         hostname: 'psql',
         db_user: 'pgbackup',
         manage_dbuser: true,

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -27,6 +27,42 @@ describe 'pgbackrest::stanza' do
 
   it { is_expected.to contain_class('pgbackrest::install') }
 
+  context 'with global options' do
+    let(:params) do
+      {
+        version: '14',
+        config: {
+          'global' => {
+            'archive-async' => 'y',
+            'process-max' => 8,
+          },
+        },
+      }
+    end
+
+    it { is_expected.to compile }
+
+    it {
+      is_expected.to contain_ini_setting('global archive-async').with(
+        ensure: 'present',
+        path: '/etc/pgbackrest/pgbackrest.conf',
+        section: 'global',
+        setting: 'archive-async',
+        value: 'y',
+      )
+    }
+
+    it {
+      is_expected.to contain_ini_setting('global process-max').with(
+        ensure: 'present',
+        path: '/etc/pgbackrest/pgbackrest.conf',
+        section: 'global',
+        setting: 'process-max',
+        value: 8,
+      )
+    }
+  end
+
   context 'backup db' do
     let(:params) do
       {

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -398,4 +398,53 @@ describe 'pgbackrest::stanza' do
         .with_content(%r{pg2-host-port = 2222})
     end
   end
+
+  context 'primary role detected from pg_is_in_recovery fact' do
+    let(:facts) { os_facts.merge('pgbackrest' => { 'in_recovery' => false }) }
+    let(:params) do
+      {
+        backups: {
+          common: {
+            full: {},
+          },
+        },
+        hostname: 'psql2',
+        cluster: 'psql',
+        id: 2,
+        version: '14',
+      }
+    end
+
+    it 'exports per-cluster singleton resources despite id != 1' do
+      expect(exported_resources).to contain_exec('pgbackrest_stanza_create_psql.localhost-common')
+      expect(exported_resources).to contain_cron('pgbackrest_full_psql.localhost-common')
+    end
+  end
+
+  context 'standby role detected from pg_is_in_recovery fact' do
+    let(:facts) { os_facts.merge('pgbackrest' => { 'in_recovery' => true }) }
+    let(:params) do
+      {
+        backups: {
+          common: {
+            full: {},
+          },
+        },
+        hostname: 'psql',
+        cluster: 'psql',
+        id: 1,
+        version: '14',
+      }
+    end
+
+    it 'does not export per-cluster singleton resources despite id == 1' do
+      expect(exported_resources).not_to contain_exec('pgbackrest_stanza_create_psql.localhost-common')
+      expect(exported_resources).not_to contain_cron('pgbackrest_full_psql.localhost-common')
+    end
+
+    it 'explicit primary parameter overrides the fact' do
+      params[:primary] = true
+      expect(exported_resources).to contain_exec('pgbackrest_stanza_create_psql.localhost-common')
+    end
+  end
 end

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -102,6 +102,57 @@ describe 'pgbackrest::stanza' do
     }
   end
 
+  context 'manage ssh keys with default ssh_user' do
+    let(:params) do
+      {
+        hostname: 'psql',
+        manage_ssh_keys: true,
+        ssh_key_type: 'ed25519',
+        version: '14',
+        db_path: '/var/lib/postgresql',
+      }
+    end
+
+    it 'generates the ssh key pair under the ssh_user home, not the backup user home' do
+      is_expected.to contain_exec('pgbackrest-generate-ssh-key_postgres').with(
+        command: 'su - postgres -c "ssh-keygen -t ed25519 -q -N \'\' -f /var/lib/postgresql/.ssh/id_ed25519"',
+      )
+    end
+
+    it {
+      is_expected.to contain_file('/var/lib/postgresql/.ssh')
+        .with(ensure: 'directory',
+            owner: 'postgres')
+    }
+
+    it {
+      expect(exported_resources).to contain_ssh_authorized_key('postgres-psql.localhost')
+        .with(
+          user: 'pgbackup',
+          type: 'ssh-ed25519',
+          key: 'AAAABBBBCC1lZDI1NTE5AAAAIN1UTKrM47QYBXJg0cIgrausN4o93I17AIj4K3i+5yS4',
+          tag: ['pgbackrest-common'],
+        )
+    }
+
+    it {
+      is_expected.to contain_file('/var/cache/pgbackrest')
+        .with(ensure: 'directory',
+            owner: 'postgres',
+            group: 'postgres')
+    }
+
+    it {
+      is_expected.to contain_ini_setting('pgbackrest-stanza').with(
+        {
+          ensure: 'present',
+          setting: 'postgres', value: '/var/lib/postgresql/.ssh/id_ed25519.pub',
+          path: '/var/cache/pgbackrest/exported_keys.ini'
+        },
+      )
+    }
+  end
+
   context 'with plain text password' do
     let(:params) do
       {

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -298,6 +298,8 @@ describe 'pgbackrest::stanza' do
       }
     end
 
+    it { is_expected.to compile }
+
     it {
       expect(exported_resources).to contain_exec('pgbackrest_stanza_create_psql.localhost-common').with(
         tag: 'pgbackrest_stanza_create-common',

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -318,7 +318,7 @@ describe 'pgbackrest::stanza' do
     }
 
     it 'exports member config for the repository' do
-      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-psql.conf')
+      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-1.conf')
         .with(tag: ['pgbackrest-common'])
         .with_content(%r{\[psql\]})
         .with_content(%r{pg1-host = psql\.localhost})
@@ -358,7 +358,7 @@ describe 'pgbackrest::stanza' do
     it { is_expected.to compile }
 
     it 'exports member config with its own pg index' do
-      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-psql2.conf')
+      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-2.conf')
         .with(tag: ['pgbackrest-common'])
         .with_content(%r{\[psql\]})
         .with_content(%r{pg2-host = psql\.localhost})
@@ -394,7 +394,7 @@ describe 'pgbackrest::stanza' do
     end
 
     it 'exports member config with pg-host-port' do
-      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-psql2.conf')
+      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-2.conf')
         .with_content(%r{pg2-host-port = 2222})
     end
   end

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -311,9 +311,90 @@ describe 'pgbackrest::stanza' do
     }
 
     it {
+      expect(exported_resources).to contain_cron('pgbackrest_full_psql.localhost-common').with(
+        tag: 'pgbackrest-common',
+      )
+    }
+
+    it 'exports member config for the repository' do
+      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-psql.conf')
+        .with(tag: ['pgbackrest-common'])
+        .with_content(%r{\[psql\]})
+        .with_content(%r{pg1-host = psql\.localhost})
+        .with_content(%r{pg1-host-user = postgres})
+        .with_content(%r{pg1-path = /var/lib/postgresql/14/main})
+        .with_content(%r{pg1-port = 5432})
+    end
+
+    it 'keeps pg-host out of the local config' do
+      is_expected.to contain_file('/etc/pgbackrest/conf.d/psql.conf')
+        .with_content(%r{pg1-path = /var/lib/postgresql/14/main})
+        .without_content(%r{pg1-host})
+    end
+
+    it {
       is_expected.to contain_postgresql__server__database('backup').with(
         { 'owner' => 'pgbackup' },
       )
     }
+  end
+
+  context 'standby replica' do
+    let(:params) do
+      {
+        backups: {
+          common: {
+            incr: {},
+          },
+        },
+        hostname: 'psql2',
+        cluster: 'psql',
+        id: 2,
+        version: '14',
+      }
+    end
+
+    it { is_expected.to compile }
+
+    it 'exports member config with its own pg index' do
+      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-psql2.conf')
+        .with(tag: ['pgbackrest-common'])
+        .with_content(%r{\[psql\]})
+        .with_content(%r{pg2-host = psql\.localhost})
+        .with_content(%r{pg2-path = /var/lib/postgresql/14/main})
+        .without_content(%r{pg1-})
+    end
+
+    it 'does not export per-cluster singleton resources' do
+      expect(exported_resources).not_to contain_exec('pgbackrest_stanza_create_psql.localhost-common')
+      expect(exported_resources).not_to contain_cron('pgbackrest_incr_psql.localhost-common')
+    end
+
+    it 'writes local config with its own pg index and no pg-host' do
+      is_expected.to contain_file('/etc/pgbackrest/conf.d/psql.conf')
+        .with_content(%r{pg2-path = /var/lib/postgresql/14/main})
+        .without_content(%r{pg2-host})
+    end
+
+    it 'still imports repository connection settings and exports pgpass entries' do
+      expect(exported_resources).to contain_file_line('pgbackrest_pgpass_content-psql2')
+    end
+  end
+
+  context 'standby replica with custom ssh port' do
+    let(:params) do
+      {
+        hostname: 'psql2',
+        cluster: 'psql',
+        id: 2,
+        ssh_port: 2222,
+        version: '14',
+      }
+    end
+
+    it 'exports member config with pg-host-port' do
+      expect(exported_resources).to contain_file('/etc/pgbackrest/conf.d/psql-psql2.conf')
+        .with_content(%r{pg2-host-port = 2222})
+    end
   end
 end

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -399,6 +399,42 @@ describe 'pgbackrest::stanza' do
     end
   end
 
+  context 'standalone instance with a b-suffixed hostname' do
+    let(:facts) do
+      os_facts.merge(networking: os_facts[:networking].merge('hostname' => 'psql01b'))
+    end
+    let(:params) do
+      {
+        hostname: 'psql01b',
+        version: '14',
+      }
+    end
+
+    it 'uses pg1 regardless of the hostname suffix' do
+      is_expected.to contain_file('/etc/pgbackrest/conf.d/psql01b.conf')
+        .with_content(%r{pg1-path})
+        .without_content(%r{pg2-})
+    end
+  end
+
+  context 'clustered instance with a b-suffixed hostname' do
+    let(:facts) do
+      os_facts.merge(networking: os_facts[:networking].merge('hostname' => 'psql01b'))
+    end
+    let(:params) do
+      {
+        hostname: 'psql01b',
+        cluster: 'psql01',
+        version: '14',
+      }
+    end
+
+    it 'derives pg2 from the hostname suffix' do
+      is_expected.to contain_file('/etc/pgbackrest/conf.d/psql01.conf')
+        .with_content(%r{pg2-path})
+    end
+  end
+
   context 'primary role detected from pg_is_in_recovery fact' do
     let(:facts) { os_facts.merge('pgbackrest' => { 'in_recovery' => false }) }
     let(:params) do

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -306,6 +306,7 @@ describe 'pgbackrest::stanza' do
       expect(exported_resources).to contain_exec('pgbackrest_stanza_create_psql.localhost-common').with(
         tag: 'pgbackrest_stanza_create-common',
         command: 'pgbackrest stanza-create --stanza=psql',
+        onlyif: "pgbackrest info --stanza=psql | grep -q 'missing stanza'",
       )
     }
 

--- a/spec/classes/stanza_spec.rb
+++ b/spec/classes/stanza_spec.rb
@@ -292,6 +292,8 @@ describe 'pgbackrest::stanza' do
           },
         },
         hostname: 'psql',
+        db_user: 'pgbackup',
+        manage_dbuser: true,
         manage_ssh_keys: false,
         manage_host_keys: false,
         version: '14',

--- a/spec/defines/cron_backup_spec.rb
+++ b/spec/defines/cron_backup_spec.rb
@@ -9,6 +9,7 @@ describe 'pgbackrest::cron_backup' do
   let(:params) do
     {
       hostname: 'psql01a',
+      id: 1,
       repo: 1,
       cluster: 'psql01',
       host_group: 'common',

--- a/spec/defines/cron_backup_spec.rb
+++ b/spec/defines/cron_backup_spec.rb
@@ -33,4 +33,46 @@ describe 'pgbackrest::cron_backup' do
         minute: '0',
       )
   }
+
+  context 'with zst compression and negative compress_level' do
+    let(:params) do
+      super().merge(compress_type: 'zst', compress_level: -7)
+    end
+
+    it { is_expected.to compile }
+
+    it {
+      expect(exported_resources).to contain_cron('pgbackrest_incr_localhost-common')
+        .with(command: %r{--compress-type=zst --compress-level=-7})
+    }
+  end
+
+  context 'with maximum zst compress_level' do
+    let(:params) do
+      super().merge(compress_type: 'zst', compress_level: 22)
+    end
+
+    it { is_expected.to compile }
+
+    it {
+      expect(exported_resources).to contain_cron('pgbackrest_incr_localhost-common')
+        .with(command: %r{--compress-type=zst --compress-level=22})
+    }
+  end
+
+  context 'with compress_level below allowed range' do
+    let(:params) do
+      super().merge(compress_type: 'zst', compress_level: -8)
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{compress_level}) }
+  end
+
+  context 'with compress_level above allowed range' do
+    let(:params) do
+      super().merge(compress_type: 'zst', compress_level: 23)
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{compress_level}) }
+  end
 end

--- a/spec/functions/instance_id_spec.rb
+++ b/spec/functions/instance_id_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'pgbackrest::instance_id' do
+  it { is_expected.to run.with_params('psql01a.de').and_return(1) }
+  it { is_expected.to run.with_params('psql01b.de').and_return(2) }
+  it { is_expected.to run.with_params('psql02a.de').and_return(1) }
+  it { is_expected.to run.with_params('psql01b.de.recombee.net').and_return(2) }
+  it { is_expected.to run.with_params('psql01c').and_return(3) }
+  it { is_expected.to run.with_params('PSQL01B').and_return(2) }
+
+  # no member suffix: standalone server, treated as the first (primary) member
+  it { is_expected.to run.with_params('psql01').and_return(1) }
+  it { is_expected.to run.with_params('psql01.de').and_return(1) }
+
+  # trailing letter without preceding digits is not a member suffix
+  it { is_expected.to run.with_params('alpha').and_return(1) }
+
+  it { is_expected.to run.with_params(nil).and_raise_error(StandardError) }
+end

--- a/templates/cron_backup.epp
+++ b/templates/cron_backup.epp
@@ -5,7 +5,7 @@
 <%= "/usr/bin/pgbackrest" -%>
 <% }  -%>
 <%= " backup --repo=${repo} --stanza=${cluster} --type=${backup_type}" -%>
-<%= " --pg-user ${db_user}" -%>
+<%= " --pg${id}-user ${db_user}" -%>
 <% if $process_max { -%>
 <%= " --process-max=${process_max}" -%>
 <% } -%>

--- a/templates/cron_backup.epp
+++ b/templates/cron_backup.epp
@@ -9,7 +9,10 @@
 <% if $process_max { -%>
 <%= " --process-max=${process_max}" -%>
 <% } -%>
-<%= " --compress-type=${compress_type} --compress-level=${compress_level}" -%>
+<%= " --compress-type=${compress_type}" -%>
+<% if $compress_level { -%>
+<%= " --compress-level=${compress_level}" -%>
+<% } -%>
 <% if $archive_timeout { -%>
 <%= " --archive-timeout=${archive_timeout}" -%>
 <% } -%>

--- a/types/compresslevel.pp
+++ b/types/compresslevel.pp
@@ -1,0 +1,2 @@
+# Compression level, negative values are supported by zst (valid range: -7 to 22)
+type Pgbackrest::CompressLevel = Integer[-7,22]


### PR DESCRIPTION
- switch to `postgres` user on DB server  - in order to avoid issues with insufficient permissions
- postgres is used for pushing WALs
- database dir has by default permissions `0700` (only `postgres` can read it)
- Fix compress levels, allow passing negative values
- Generate instance id from hostname, if none given
- Fix importing ssh key on repository server
- Check whether postgresql is running as standby or as primary
- Support passing `$config` to `pgbackrest::stanza`